### PR TITLE
fix(alibaba): add tag prefix for value of tag cluster

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -15,6 +15,7 @@ const (
 	K3sManifestsDir    = "/var/lib/rancher/k3s/server/manifests"
 	MasterInstanceName = "autok3s.%s.master"
 	WorkerInstanceName = "autok3s.%s.worker"
+	TagClusterPrefix   = "autok3s-"
 )
 
 var (


### PR DESCRIPTION
- add tag prefix for value of tag cluster

>From [Alibaba Cloud Doc](https://www.alibabacloud.com/help/doc-detail/128044.htm): The key must be 1 to 128 characters in length, and start with a letter or Chinese character. It can contain numbers, periods (.), underscores (_), and hyphens (-) and cannot start with `aliyun` or `acs:`. It cannot contain `http://` or `https://`.
