### PR TITLE
Update0203

### DIFF
--- a/docs/i18n/zh_cn/README.md
+++ b/docs/i18n/zh_cn/README.md
@@ -1,16 +1,21 @@
 # autok3s
+
 [![Build Status](http://drone-pandaria.cnrancher.com/api/badges/cnrancher/autok3s/status.svg)](http://drone-pandaria.cnrancher.com/cnrancher/autok3s)
-[![Go Report Card](https://goreportcard.com/badge/github.com/cnrancher/autok3s)](https://goreportcard.com/report/github.com/cnrancher/autok3s) 
+[![Go Report Card](https://goreportcard.com/badge/github.com/cnrancher/autok3s)](https://goreportcard.com/report/github.com/cnrancher/autok3s)
 ![GitHub release](https://img.shields.io/github/v/release/cnrancher/autok3s.svg?color=blue)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?color=blue)](http://github.com/cnrancher/autok3s/pulls)
 
 简体中文 / [English](../../../README.md)
 
-快速创建并启动k3s集群，同时可以使用它来为k3s集群添加节点，提升公有云体验的同时，继承kubectl从而提供便捷的集群能力。
+## 什么是 autok3s
+
+使用 K3s 在公有云中创建集群的过程比较复杂，在各个公有云中创建 K3s 集群所需填写的参数也有差异。为了降低 K3s 的使用门槛，简化使用 K3s 的过程，我们开发了 autok3s 这一款辅助工具。您可以使用 autok3s 快速创建并启动 k3s 集群，同时可以使用它来为已有的 k3s 集群添加节点，不仅提升公有云的使用体验，同时还继承了 kubectl，提供了便捷的集群能力。目前 autok3s 支持的云服务提供商包括**阿里云、腾讯云和 AWS**，如果您使用的云服务提供商不属于以上三家，您可以使用`native`模式，在任意类型的虚拟机实例中初始化 k3s 集群。在后续的开发过程中，我们会考虑为其他云服务提供商提供适配。
 
 <!-- toc -->
 
 - [关键特性](#关键特性)
+- [常用命令](#常用命令)
+- [常用参数](#常用参数)
 - [支持的云提供商](#支持的云提供商)
 - [快速体验](#快速体验)
 - [演示视频](#演示视频)
@@ -20,6 +25,7 @@
 <!-- /toc -->
 
 ## 关键特性
+
 - 使用 `autok3s create` 命令，在多个公有云提供商中快速启动 Kubernetes (k3s) 集群
 - 使用 `autok3s join` 命令，添加节点至已存在的 Kubernetes (k3s) 集群
 - 自动为创建的 Kubernetes (k3s) 集群生成可供访问的 `kubeconfig` 文件
@@ -28,42 +34,101 @@
 - 使用`--registry`以支持配置`containerd`私有镜像仓库
 - 集成扩展参数 `--cloud-controller-manager` 以开启 Kubernetes Cloud-Controller-Manager 组件
 - 集成扩展参数 `--ui` 以开启 Kubernetes Dashboard UI 组件
-- 集成扩展参数 `例如 --terway 'eni'` 以开启公有云 CNI 网络插件
+- 集成扩展参数  例如 `--terway 'eni'` 以开启公有云 CNI 网络插件
+
+## 常用命令
+
+- `autok3s create`：创建和启动 k3s 集群
+- `autok3s join`：为已有的 k3s 集群添加节点
+
+## 常用参数
+
+autok3s 命令中常用的参数如下表所示：
+
+| 参数                         | 描述                                            |
+| :--------------------------- | :---------------------------------------------- |
+| `-d`                         | 使 autok3s 在后台运行。                         |
+| `-p`                         | provider，即云服务提供商，详情参考下表。        |
+| `--name`                     | 指定将要创建的集群的名称。                      |
+| `--master`                   | 指定创建的 master 节点数量 。                   |
+| `--worker`                   | 指定创建的 worker 节点数量 。                   |
+| `--registry`                 | 配置`containerd`私有镜像仓库。                  |
+| `--cloud-controller-manager` | 开启 Kubernetes Cloud-Controller-Manager 组件。 |
+| `--ui`                       | 开启 Kubernetes Dashboard UI 组件。             |
+| `--terway 'eni'`             | 开启公有云 CNI 网络插件。                       |
+
+### 云服务提供商参数描述
+
+| 参数         | 描述                       |
+| :----------- | :------------------------- |
+| `-p alibaba` | 指定阿里云作为云服务提供商 |
+| `-p tencent` | 指定腾讯云作为云服务提供商 |
+| `-p aws`     | 指定 AWS 作为云服务提供商  |
 
 ## 支持的云提供商
+
 有关更多用法的详细信息，请参见下面的链接：
 
-- [alibaba](alibaba/README.md) - 在阿里云的 ECS 中初始化 Kubernetes (k3s) 集群
-- [tencent](tencent/README.md) - 在腾讯云 CVM 中初始化 Kubernetes (k3s) 集群
-- [native](native/README.md) - 在任意类型 VM 实例中初始化 Kubernetes (k3s) 集群
+- [阿里云](alibaba/README.md) - 在阿里云的 ECS 中初始化 Kubernetes (k3s) 集群。
+- [腾讯云]](tencent/README.md) - 在腾讯云 CVM 中初始化 Kubernetes (k3s) 集群。
+- [AWS](aws/README.md) - 在 AWS EC2 中初始化 Kubernetes (k3s) 集群。
+- [native](native/README.md) - 在任意类型 VM 实例中初始化 Kubernetes (k3s) 集群。
 
-## 快速体验
-以下命令使用`alibaba`作为云提供商，相关的前置条件请参考[alibaba](alibaba/README.md)云提供商文档。
+## 示例
+
+`autok3s create` 和 `autok3s join`这两个常用的 autok3s 命令通常需要配合多个参数使用，以下是两个命令的使用示例。您可以调整的参数包括：云供应商、节点名称、master 节点数量和 worker 节点数量。
+
+### 创建 k3s 集群
+
+以下代码是创建 k3s 集群的示例。这个命令使用了阿里云`alibaba`作为云提供商，在阿里云上创建了一个名为 “myk3s”的集群，并为该集群配置了 1 个 master 节点和 1 个 worker 节点。
 
 ```bash
-export ECS_ACCESS_KEY_ID='<Your access key ID>'
-export ECS_ACCESS_KEY_SECRET='<Your secret access key>'
-
 autok3s -d create -p alibaba --name myk3s --master 1 --worker 1
 ```
 
-## 演示视频
-示程序在1分钟左右就能将Kubernetes (k3s)安装到阿里云的ECS实例上。
+### 添加 k3s 节点
 
-观看演示:
+以下代码是为已有的 k3s 集群添加 k3s 节点的示例。名为“myk3s”的集群是已经运行在阿里云上 的 k3s 集群。这个命令使用了阿里云`alibaba`作为云提供商，为“myk3s”集群添加了 1 个 worker 节点。
+
+```bash
+autok3s -d join --provider alibaba --name myk3s --worker 1
+```
+
+### 总结
+
+`autok3s create` 命令的表达式可以抽象概括为：
+
+```bash
+autok3s -d create -p <云服务提供商> --name <集群名称> --master <master节点数量> --worker <worker节点数量>
+```
+
+`autok3s join`命令的表达式可以抽象概括为：
+
+```bash
+autok3s -d join -p <云服务提供商> --name <集群名称> --master <master节点数量> --worker <worker节点数量>
+```
+
+其中，`-p <云服务提供商>`和`--name <集群名称>`为必填项，用于指定云服务提供商和添加的集群名称；`--master <master节点数量>`，`--worker <worker节点数量>`为选填项，用于指定添加的节点数量，如果您只需要单独添加 master 或 worker 节点，则可以不填写另一个类型节点的参数和指定这个类型的节点数量。
+
+## 演示视频
+
+本视频展示了 autok3s 在阿里云的 ECS 实例上安装 k3s 的过程和步骤，autok3s 只需要 1 分钟左右就能将 Kubernetes (k3s)安装到阿里云的 ECS 实例上。
+
+观看演示：
 
 [![asciicast](https://asciinema.org/a/EL5P2ILES8GAvdlhaxLMnY8Pg.svg)](https://asciinema.org/a/EL5P2ILES8GAvdlhaxLMnY8Pg)
 
 ## 开发者指南
+
 使用 `Makefile` 管理项目的编译、测试与打包。
 项目支持使用 `dapper`，`dapper`安装步骤请参考[dapper](https://github.com/rancher/dapper)。
 
-- 依赖: `GO111MODULE=on go mod vendor`
-- 编译: `BY=dapper make autok3s`
-- 测试: `BY=dapper make autok3s unit`
-- 打包: `BY=dapper make autok3s package only`
+- 依赖：`GO111MODULE=on go mod vendor`
+- 编译：`BY=dapper make autok3s`
+- 测试：`BY=dapper make autok3s unit`
+- 打包：`BY=dapper make autok3s package only`
 
-# 开源协议
+## 开源协议
 
 Copyright (c) 2020 [Rancher Labs, Inc.](http://rancher.com)
 

--- a/docs/i18n/zh_cn/README.md
+++ b/docs/i18n/zh_cn/README.md
@@ -47,7 +47,7 @@ autok3s 命令中常用的参数如下表所示：
 
 | 参数                         | 描述                                            |
 | :--------------------------- | :---------------------------------------------- |
-| `-d`                         | 使 autok3s 在后台运行。                         |
+| `-d`                         | 开启 debug 模式。                               |
 | `-p`                         | provider，即云服务提供商，详情参考下表。        |
 | `--name`                     | 指定将要创建的集群的名称。                      |
 | `--master`                   | 指定创建的 master 节点数量 。                   |
@@ -55,7 +55,7 @@ autok3s 命令中常用的参数如下表所示：
 | `--registry`                 | 配置`containerd`私有镜像仓库。                  |
 | `--cloud-controller-manager` | 开启 Kubernetes Cloud-Controller-Manager 组件。 |
 | `--ui`                       | 开启 Kubernetes Dashboard UI 组件。             |
-| `--terway 'eni'`             | 开启公有云 CNI 网络插件。                       |
+| `--terway 'eni'`             | 开启公有云 CNI 网络插件（仅适用于阿里云）。     |
 
 ### 云服务提供商参数描述
 
@@ -70,7 +70,7 @@ autok3s 命令中常用的参数如下表所示：
 有关更多用法的详细信息，请参见下面的链接：
 
 - [阿里云](alibaba/README.md) - 在阿里云的 ECS 中初始化 Kubernetes (k3s) 集群。
-- [腾讯云]](tencent/README.md) - 在腾讯云 CVM 中初始化 Kubernetes (k3s) 集群。
+- [腾讯云](tencent/README.md) - 在腾讯云 CVM 中初始化 Kubernetes (k3s) 集群。
 - [AWS](aws/README.md) - 在 AWS EC2 中初始化 Kubernetes (k3s) 集群。
 - [native](native/README.md) - 在任意类型 VM 实例中初始化 Kubernetes (k3s) 集群。
 

--- a/docs/i18n/zh_cn/aws/README.md
+++ b/docs/i18n/zh_cn/aws/README.md
@@ -1,10 +1,13 @@
-# Amazone Provider
-在亚马逊创建对应的EC2实例，通过所创建的实例初始化k3s集群，或将一个或多个EC2实例作为k3s节点加入到k3s集群中。
+# aws Provider
+
+在亚马逊创建对应的 EC2 实例，通过所创建的实例初始化 k3s 集群，或将一个或多个 EC2 实例作为 k3s 节点加入到 k3s 集群中。
 
 ## 前置要求
-为了确保EC2实例被正确创建及访问，请检查并设置以下内容。
+
+为了确保 EC2 实例被正确创建及访问，请检查并设置以下内容。
 
 ### 设置环境变量
+
 为运行`autok3s`命令的主机设置以下环境变量:
 
 ```bash
@@ -13,10 +16,12 @@ export AWS_SECRET_ACCESS_KEY='<secret-key>'
 ```
 
 ### 设置 IAM
-关于IAM的描述，请参考[这里](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html?icmpid=docs_iam_console).
 
-您的账号需要创建EC2及相关资源的权限，因此需要确保具有以下资源的权限。
+关于 IAM 的描述，请参考[这里](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html?icmpid=docs_iam_console).
+
+您的账号需要创建 EC2 及相关资源的权限，因此需要确保具有以下资源的权限。
 您可以参考一下权限。
+
 ```
 {
     "Version": "2012-10-17",
@@ -45,7 +50,8 @@ export AWS_SECRET_ACCESS_KEY='<secret-key>'
 ```
 
 ### 设置安全组
-EC2实例需要应用以下安全组规则:
+
+EC2 实例需要应用以下安全组规则:
 
 ```bash
 Rule        Protocol    Port      Source             Description
@@ -59,56 +65,62 @@ OutBound    ALL         ALL       ALL                Allow All
 ```
 
 ## 使用方式
-更多参数请运行`autok3s <sub-command> --provider amazone --help`命令。
+
+更多参数请运行`autok3s <sub-command> --provider aws --help`命令。
 
 ### 快速启动
-创建并启动一个k3s集群，这里集群为myk3s。
+
+创建并启动一个 k3s 集群，这里集群为 myk3s。
 
 ```bash
-autok3s -d create -p amazone --name myk3s --master 1 --worker 1
+autok3s -d create -p aws --name myk3s --master 1 --worker 1
 ```
 
-### 创建高可用K3s集群
-高可用模式(嵌入式etcd: k3s版本 >= 1.19.1-k3s1)
+### 创建高可用 K3s 集群
+
+高可用模式(嵌入式 etcd: k3s 版本 >= 1.19.1-k3s1)
 
 ```bash
-autok3s -d create -p amazone --name myk3s --master 3 --cluster
+autok3s -d create -p aws --name myk3s --master 3 --cluster
 ```
 
-高可用模式(外部数据库) 要求 `--master` 至少为1, 并且需要指定参数 `--datastore`。
+高可用模式(外部数据库) 要求 `--master` 至少为 1, 并且需要指定参数 `--datastore`。
 
 ```bash
-autok3s -d create -p amazone --name myk3s --master 2 --datastore "mysql://<user>:<password>@tcp(<ip>:<port>)/<db>"
+autok3s -d create -p aws --name myk3s --master 2 --datastore "mysql://<user>:<password>@tcp(<ip>:<port>)/<db>"
 ```
 
-### 添加K3s节点
-请指定你要添加K3s master/agent节点的集群, 这里为myk3s集群添加节点。
+### 添加 K3s 节点
+
+请指定你要添加 K3s master/agent 节点的集群, 这里为 myk3s 集群添加节点。
 
 ```bash
-autok3s -d join --provider amazone --name myk3s --worker 1
+autok3s -d join --provider aws --name myk3s --worker 1
 ```
 
-为高可用集群(嵌入式etcd: k3s版本 >= 1.19.1-k3s1)模式新增节点。
+为高可用集群(嵌入式 etcd: k3s 版本 >= 1.19.1-k3s1)模式新增节点。
 
 ```bash
-autok3s -d join --provider amazone --name myk3s --master 2
+autok3s -d join --provider aws --name myk3s --master 2
 ```
 
 为高可用集群(外部数据库)新增节点，需要指定参数`--datastore`。
 
 ```bash
-autok3s -d join --provider amazone --name myk3s --master 2 --datastore "mysql://<user>:<password>@tcp(<ip>:<port>)/<db>"
+autok3s -d join --provider aws --name myk3s --master 2 --datastore "mysql://<user>:<password>@tcp(<ip>:<port>)/<db>"
 ```
 
-### 删除K3s集群
-删除一个k3s集群，这里删除的集群为myk3s。
+### 删除 K3s 集群
+
+删除一个 k3s 集群，这里删除的集群为 myk3s。
 
 ```bash
-autok3s -d delete --provider amazone --name myk3s
+autok3s -d delete --provider aws --name myk3s
 ```
 
 ### 查看集群列表
-显示当前主机上管理的所有K3s集群列表。
+
+显示当前主机上管理的所有 K3s 集群列表。
 
 ```bash
 autok3s list
@@ -116,20 +128,22 @@ autok3s list
 
 ```bash
 NAME         REGION      PROVIDER  STATUS   MASTERS  WORKERS    VERSION
-myk3s    ap-southeast-2  amazone   Running  1        0        v1.20.2+k3s1
+myk3s    ap-southeast-2  aws   Running  1        0        v1.20.2+k3s1
 ```
 
 ### 查看集群详细信息
-显示具体的k3s信息，包括实例状态、主机ip、集群版本等信息。
+
+显示具体的 k3s 信息，包括实例状态、主机 ip、集群版本等信息。
 
 ```bash
 autok3s describe cluster <clusterName>
 ```
-> 注意：如果使用不同的provider创建的集群名称相同，describe时会显示多个集群信息，可以使用`-p <provider> -r <region>`对provider及region进一步过滤。e.g. `autok3s describe cluster <clusterName> -p amazone -r <region>`
+
+> 注意：如果使用不同的 provider 创建的集群名称相同，describe 时会显示多个集群信息，可以使用`-p <provider> -r <region>`对 provider 及 region 进一步过滤。e.g. `autok3s describe cluster <clusterName> -p aws -r <region>`
 
 ```bash
 Name: myk3s
-Provider: amazone
+Provider: aws
 Region: ap-southeast-2
 Zone: ap-southeast-2c
 Master: 1
@@ -149,10 +163,11 @@ Nodes:
 ```
 
 ### Kubectl
+
 集群创建完成后, `autok3s` 会自动合并 `kubeconfig` 文件。
 
 ```bash
-autok3s kubectl config use-context myk3s.ap-southeast-2.amazone
+autok3s kubectl config use-context myk3s.ap-southeast-2.aws
 autok3s kubectl <sub-commands> <flags>
 ```
 
@@ -164,28 +179,32 @@ autok3s kubectl config use-context <context>
 ```
 
 ### SSH
-SSH连接到集群中的某个主机，这里选择的集群为myk3s。
+
+SSH 连接到集群中的某个主机，这里选择的集群为 myk3s。
 
 ```bash
-autok3s ssh --provider amazone --name myk3s
+autok3s ssh --provider aws --name myk3s
 ```
 
 ## 进阶使用
-我们集成了一些与当前provider有关的高级组件，例如ccm、ui。
+
+我们集成了一些与当前 provider 有关的高级组件，例如 ccm、ui。
 
 ### Setup Private Registry
+
 在运行`autok3s create`或`autok3s join`时，通过传递`--registry /etc/autok3s/registries.yaml`以使用私有镜像仓库，例如：
 
 ```bash
 autok3s -d create \
-    --provider amazone \
+    --provider aws \
     --name myk3s \
     --master 1 \
     --worker 1 \
     --registry /etc/autok3s/registries.yaml
 ```
 
-使用私有镜像仓库的配置请参考以下内容，如果您的私有镜像仓库需要TLS认证，`autok3s`会从本地读取相关的TLS文件并自动上传到远程服务器中完成配置，您只需要完善`registry.yaml`即可。
+使用私有镜像仓库的配置请参考以下内容，如果您的私有镜像仓库需要 TLS 认证，`autok3s`会从本地读取相关的 TLS 文件并自动上传到远程服务器中完成配置，您只需要完善`registry.yaml`即可。
+
 ```bash
 mirrors:
   docker.io:
@@ -202,9 +221,9 @@ configs:
       ca_file:   # path to the ca file used in the registry
 ```
 
-### 启用AWS Cloud Controller Manager
+### 启用 AWS Cloud Controller Manager
 
-如果您要使用AWS CCM功能需要提前准备好两个IAM policies，以保证CCM功能的正常使用，具体内容请参考[这里](https://kubernetes.github.io/cloud-provider-aws/prerequisites.html)
+如果您要使用 AWS CCM 功能需要提前准备好两个 IAM policies，以保证 CCM 功能的正常使用，具体内容请参考[这里](https://kubernetes.github.io/cloud-provider-aws/prerequisites.html)
 
 ```bash
 autok3s -d create \
@@ -214,9 +233,10 @@ autok3s -d create \
     --iam-instance-profile-worker <iam policy for node>
 ```
 
-### 启用UI组件
+### 启用 UI 组件
+
 该参数会启用 [kubernetes/dashboard](https://github.com/kubernetes/dashboard) 图形界面。
-访问Token等设置请参考 [此文档](https://github.com/kubernetes/dashboard/blob/master/docs/user/access-control/creating-sample-user.md) 。
+访问 Token 等设置请参考 [此文档](https://github.com/kubernetes/dashboard/blob/master/docs/user/access-control/creating-sample-user.md) 。
 
 ```bash
 autok3s -d create \


### PR DESCRIPTION
修改了readme主页和aws页面的一些描述：

- amazone --- 拼写错了，应该改为 amazon或 aws，昨天跟超姐讨论之后决定改为 aws。代码里面的变量名称估计也需要改 @JacieChao
- ”关键特性“这一栏描述的东西其实是糅杂了2~3个不同的内容：功能/关键特性、常用命令和参数。所以我将”关键特性“分成了三个章节描述：关键特性、常用命令和常用参数。 @Jason-ZW @JacieChao jacie如果还有其他没列出来的命令或参数，请补充上去。
- 完善了”示例“章节

https://github.com/cnrancher/autok3s/pull/222