### PR TITLE
docs(autok3s): update docs

### DIFF
--- a/docs/i18n/en_us/aws/README.md
+++ b/docs/i18n/en_us/aws/README.md
@@ -1,11 +1,14 @@
 # AWS Provider
-It uses the Amazon Cloud SDK to create and manage EC2 instances, and then uses SSH to install k3s cluster to the remove host.
+
+It uses the AWS Cloud SDK to create and manage EC2 instances, and then uses SSH to install k3s cluster to the remove host.
 You can also use it to join hosts as masters/agents to the k3s cluster.
 
 ## Pre-Requests
+
 To ensure that EC2 instances can be created and accessed normally, please check and set the following configuration.
 
 ### Setup Environment
+
 Configure the following environment variables for the host which running `autok3s`.
 
 ```bash
@@ -14,11 +17,13 @@ export AWS_SECRET_ACCESS_KEY='<secret-key>'
 ```
 
 ### Setup IAM
+
 Please refer [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html?icmpid=docs_iam_console) for more IAM settings.
 
 Please make sure your account has permission to manage EC2 instance or other relative resources.
 
 For example:
+
 ```
 {
     "Version": "2012-10-17",
@@ -52,6 +57,7 @@ For example:
 ```
 
 ### Setup Security Group
+
 The ECS instances need to apply the following Security Group Rules:
 
 ```bash
@@ -66,9 +72,11 @@ OutBound    ALL         ALL       ALL                Allow All
 ```
 
 ## Usage
+
 More usage details please running `autok3s <sub-command> --provider aws --help` commands.
 
 ### Quick Start
+
 Create and Start 1 master & 1 worker(agent) k3s cluster.
 
 ```bash
@@ -76,6 +84,7 @@ autok3s -d create -p aws --name myk3s --master 1 --worker 1
 ```
 
 ### Setup K3s HA Cluster
+
 HA(embedded etcd: >= 1.19.1-k3s1) mode. e.g.
 
 ```bash
@@ -89,13 +98,14 @@ autok3s -d create -p aws --name myk3s --master 2 --datastore "mysql://<user>:<pa
 ```
 
 ### Join K3s Nodes
+
 To join master/agent nodes, specify the cluster you want to add, e.g myk3s.
 
 ```bash
 autok3s -d join --provider aws --name myk3s --worker 1
 ```
 
-Join master nodes to (embedded etcd: >= 1.19.1-k3s1) HA cluster.  e.g.
+Join master nodes to (embedded etcd: >= 1.19.1-k3s1) HA cluster. e.g.
 
 ```bash
 autok3s -d join --provider aws --name myk3s --master 2
@@ -108,6 +118,7 @@ autok3s -d join --provider aws --name myk3s --master 2 --datastore "mysql://<use
 ```
 
 ### Delete K3s Cluster
+
 This command will delete a k3s cluster, e.g myk3s.
 
 ```bash
@@ -115,6 +126,7 @@ autok3s -d delete --provider aws --name myk3s
 ```
 
 ### List K3s Clusters
+
 This command will list the clusters that you have created on this machine.
 
 ```bash
@@ -127,11 +139,13 @@ myk3s    ap-southeast-2  aws   Running  1        0        v1.20.2+k3s1
 ```
 
 ### Describe k3s cluster
+
 This command will show detail information of specified cluster, such as instance status, node IP, kubelet version, etc.
 
 ```bash
 autok3s describe cluster <clusterName>
 ```
+
 > Note：There will be multiple results if using the same name to create with different providers, please use `-p <provider> -r <region>` to choose specified cluster. e.g. `autok3s describe cluster <clusterName> -p aws -r <region>`
 
 ```bash
@@ -156,6 +170,7 @@ Nodes:
 ```
 
 ### Access K3s Cluster
+
 After the cluster created, `autok3s` will automatically merge the `kubeconfig` which necessary for us to access the cluster.
 
 ```bash
@@ -171,6 +186,7 @@ autok3s kubectl config use-context <context>
 ```
 
 ### SSH K3s Cluster's Node
+
 Login to specified k3s cluster node via ssh, e.g myk3s.
 
 ```bash
@@ -178,9 +194,11 @@ autok3s ssh --provider aws --name myk3s
 ```
 
 ## Advanced Usage
+
 We integrate some advanced components related to the current provider, e.g. ccm/ui.
 
 ### Setup Private Registry
+
 Below are examples showing how you may configure `/etc/autok3s/registries.yaml` on your current node when using TLS, and make it take effect on k3s cluster by `autok3s`.
 
 ```bash
@@ -223,6 +241,7 @@ autok3s -d create -p aws \
 ```
 
 ### Enable UI Component
+
 This flag will enable [kubernetes/dashboard](https://github.com/kubernetes/dashboard) UI component.
 Please following this [docs](https://github.com/kubernetes/dashboard/blob/master/docs/user/access-control/creating-sample-user.md) to create user token.
 

--- a/docs/i18n/zh_cn/README.md
+++ b/docs/i18n/zh_cn/README.md
@@ -68,9 +68,9 @@ autok3s join -p alibaba --name myk3s --worker 1
 
 ## 演示视频
 
-示程序在 1 分钟左右就能将 Kubernetes (k3s)安装到阿里云的 ECS 实例上。
+以下这个演示程序在 1 分钟左右就能将 Kubernetes (k3s)安装到阿里云的 ECS 实例上。
 
-观看演示:
+观看演示：
 
 [![asciicast](https://asciinema.org/a/EL5P2ILES8GAvdlhaxLMnY8Pg.svg)](https://asciinema.org/a/EL5P2ILES8GAvdlhaxLMnY8Pg)
 
@@ -79,10 +79,10 @@ autok3s join -p alibaba --name myk3s --worker 1
 使用 `Makefile` 管理项目的编译、测试与打包。
 项目支持使用 `dapper`，`dapper`安装步骤请参考[dapper](https://github.com/rancher/dapper)。
 
-- 依赖: `GO111MODULE=on go mod vendor`
-- 编译: `BY=dapper make autok3s`
-- 测试: `BY=dapper make autok3s unit`
-- 打包: `BY=dapper make autok3s package only`
+- 依赖： `GO111MODULE=on go mod vendor`
+- 编译： `BY=dapper make autok3s`
+- 测试： `BY=dapper make autok3s unit`
+- 打包： `BY=dapper make autok3s package only`
 
 # 开源协议
 

--- a/docs/i18n/zh_cn/README.md
+++ b/docs/i18n/zh_cn/README.md
@@ -1,12 +1,13 @@
 # autok3s
+
 [![Build Status](http://drone-pandaria.cnrancher.com/api/badges/cnrancher/autok3s/status.svg)](http://drone-pandaria.cnrancher.com/cnrancher/autok3s)
-[![Go Report Card](https://goreportcard.com/badge/github.com/cnrancher/autok3s)](https://goreportcard.com/report/github.com/cnrancher/autok3s) 
+[![Go Report Card](https://goreportcard.com/badge/github.com/cnrancher/autok3s)](https://goreportcard.com/report/github.com/cnrancher/autok3s)
 ![GitHub release](https://img.shields.io/github/v/release/cnrancher/autok3s.svg?color=blue)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?color=blue)](http://github.com/cnrancher/autok3s/pulls)
 
 简体中文 / [English](../../../README.md)
 
-快速创建并启动k3s集群，同时可以使用它来为k3s集群添加节点，提升公有云体验的同时，继承kubectl从而提供便捷的集群能力。
+快速创建并启动 k3s 集群，同时可以使用它来为 k3s 集群添加节点，提升公有云体验的同时，继承 kubectl 从而提供便捷的集群能力。
 
 <!-- toc -->
 
@@ -20,6 +21,7 @@
 <!-- /toc -->
 
 ## 关键特性
+
 - 使用 `autok3s create` 命令，在多个公有云提供商中快速启动 Kubernetes (k3s) 集群
 - 使用 `autok3s join` 命令，添加节点至已存在的 Kubernetes (k3s) 集群
 - 自动为创建的 Kubernetes (k3s) 集群生成可供访问的 `kubeconfig` 文件
@@ -31,6 +33,7 @@
 - 集成扩展参数 `例如 --terway 'eni'` 以开启公有云 CNI 网络插件
 
 ## 支持的云提供商
+
 有关更多用法的详细信息，请参见下面的链接：
 
 - [alibaba](alibaba/README.md) - 在阿里云的 ECS 中初始化 Kubernetes (k3s) 集群
@@ -39,13 +42,24 @@
 - [aws](aws/README.md) - 在亚马逊 EC2 中初始化 Kubernetes (k3s) 集群
 
 ## 快速体验
+
 以下命令使用`alibaba`作为云提供商，相关的前置条件请参考[alibaba](alibaba/README.md)云提供商文档。
 
 ```bash
 export ECS_ACCESS_KEY_ID='<Your access key ID>'
 export ECS_ACCESS_KEY_SECRET='<Your secret access key>'
-
 autok3s -d create -p alibaba --name myk3s --master 1 --worker 1
+```
+
+### 添加 k3s 节点
+
+以下代码是为已有的 k3s 集群添加 k3s 节点的示例。名为“myk3s”的集群是已经运行在阿里云上 的 k3s 集群。这个命令使用了阿里云`alibaba`作为云提供商，为“myk3s”集群添加了 1 个 worker 节点。
+
+```bash
+export ECS_ACCESS_KEY_ID='<Your access key ID>'
+export ECS_ACCESS_KEY_SECRET='<Your secret access key>'
+
+autok3s join -p alibaba --name myk3s --worker 1
 ```
 
 ## 快速体验 UI
@@ -53,13 +67,15 @@ autok3s -d create -p alibaba --name myk3s --master 1 --worker 1
 如果您不想使用命令行工具体验，可以使用`autok3s`内置 UI 来体验相关功能，请运行命令 `autok3s serve`
 
 ## 演示视频
-示程序在1分钟左右就能将Kubernetes (k3s)安装到阿里云的ECS实例上。
+
+示程序在 1 分钟左右就能将 Kubernetes (k3s)安装到阿里云的 ECS 实例上。
 
 观看演示:
 
 [![asciicast](https://asciinema.org/a/EL5P2ILES8GAvdlhaxLMnY8Pg.svg)](https://asciinema.org/a/EL5P2ILES8GAvdlhaxLMnY8Pg)
 
 ## 开发者指南
+
 使用 `Makefile` 管理项目的编译、测试与打包。
 项目支持使用 `dapper`，`dapper`安装步骤请参考[dapper](https://github.com/rancher/dapper)。
 


### PR DESCRIPTION
修改了readme主页和aws页面的一些描述：

- amazone --- 拼写错了，应该改为 amazon或 aws，昨天跟超姐讨论之后决定改为 aws。代码里面的变量名称估计也需要改 @JacieChao

- ”关键特性“这一栏描述的东西其实是糅杂了2~3个不同的内容：功能/关键特性、常用命令和参数。所以我将”关键特性“分成了三个章节描述：关键特性、常用命令和常用参数。 @Jason-ZW @JacieChao jacie如果还有其他没列出来的命令或参数，请补充上去。

- 完善了”示例“章节

相关PR：
- https://github.com/cnrancher/autok3s/pull/223
- https://github.com/cnrancher/autok3s/pull/222