### PR TITLE
add docker-compose.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,14 @@ $ docker run -itd --restart=unless-stopped --net=host -v /var/run/docker.sock:/v
 # MacOS 
 $ docker run -itd --restart=unless-stopped -p 8080:8080 -v /var/run/docker.sock:/var/run/docker.sock cnrancher/autok3s:v0.4.5
 ```
+Scenario 2 - Run with docker-compose
+```
+docker-compose up -d
+```
+- autok3s is available at: http://autok3s.vcap.me (vcap.me resolves to 127.0.0.1)
+- cli and container uses the same `AUTOK3S_CONFIG` dir
 
-Scenario 2 - Run with CLI:
+Scenario 3 - Run with CLI:
 
 ```bash
 # The commands use the shell script on MacOS and Linux, or visit the Releases page to download the executable for Windows.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,19 @@
+services:
+  nginx-proxy:
+    image: nginxproxy/nginx-proxy
+    container_name: nginx-proxy
+    ports:
+      - "80:80"
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+  autok3s:
+    image: cnrancher/autok3s:v0.4.5
+    init: true
+    ports:
+    - 8080
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - $HOME/.autok3s/:$HOME/.autok3s/
+    environment:
+    - AUTOK3S_CONFIG=$HOME/.autok3s/
+    - VIRTUAL_HOST=autok3s.vcap.me


### PR DESCRIPTION
This docker-compose makes the following available"

- option for adding [basic auth](https://github.com/nginx-proxy/nginx-proxy#basic-authentication-support)
- cli and container uses the same `AUTOK3S_CONFIG` dir
- local server is available at: http://autok3s.vcap.me (mac/windows/linux)