### PR TITLE
fix(provider): convert int flags

### DIFF
--- a/pkg/utils/flag.go
+++ b/pkg/utils/flag.go
@@ -31,6 +31,8 @@ func ConvertFlags(cmd *cobra.Command, fs []types.Flag) *pflag.FlagSet {
 					pf.StringArrayVar(f.P.(*[]string), f.Name, t, f.Usage)
 				case types.StringArray:
 					pf.Var(newStringArrayValue(t, f.P.(*types.StringArray)), f.Name, f.Usage)
+				case int:
+					pf.IntVar(f.P.(*int), f.Name, t, f.Usage)
 				default:
 					continue
 				}


### PR DESCRIPTION

I was trying to execute the "Generate CLI Command" from the Cluster/Create dialog, but got this error message:
```
$ autok3s create --name test --master 1 --provider google  --disk-size 1 ...
Error: unknown flag: --disk-size 
```