### PR TITLE
fix(provider): add correct tag to gcp instance

### DIFF
--- a/pkg/providers/google/google.go
+++ b/pkg/providers/google/google.go
@@ -466,6 +466,9 @@ func (p *Google) startInstance(num int, master bool) error {
 			},
 		},
 		Labels: p.generateLabels(master),
+		Tags: &raw.Tags{
+			Items: []string{"autok3s"},
+		},
 		ServiceAccounts: []*raw.ServiceAccount{
 			{
 				Email:  p.ServiceAccount,


### PR DESCRIPTION
The google instance and the firewall rule is getting created, but the instance is missing the network tag, so the firewall rule is not effective.