### PR TITLE
feat(kube-explorer): bump up kube-explorer v0.2.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir /home/shell && \
     echo 'source <(kubectl completion bash)' >> /home/shell/.bashrc && \
     echo 'PS1="> "' >> /home/shell/.bashrc
 
-RUN wget -O /usr/local/bin/kube-explorer https://github.com/cnrancher/kube-explorer/releases/download/v0.2.7/kube-explorer-linux-${ARCH} && \
+RUN wget -O /usr/local/bin/kube-explorer https://github.com/cnrancher/kube-explorer/releases/download/v0.2.8/kube-explorer-linux-${ARCH} && \
     chmod +x /usr/local/bin/kube-explorer
 
 ENV AUTOK3S_CONFIG /root/.autok3s

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,7 +12,7 @@ SUCCESS_CMD="$REPO version"
 BINLOCATION=${BINLOCATION:-'/usr/local/bin'}
 KUBEEXPLORER_REPO=${KUBEEXPLORER_REPO:-'kube-explorer'}
 KUBEEXPLORER_DOWNLOAD_URL=https://github.com/$OWNER/$KUBEEXPLORER_REPO/releases/download
-KUBEEXPLORER_VERSION=v0.2.7
+KUBEEXPLORER_VERSION=v0.2.8
 
 #   - INSTALL_AUTOK3S_MIRROR
 #     For Chinese users, set INSTALL_AUTOK3S_MIRROR=cn to use the mirror address to accelerate


### PR DESCRIPTION
This version can display the name matching the `--context` parameter, instead of the hardcoded `Local`.

```
./kube-explorer --context=default .....
```
<img width="884" alt="截屏2022-02-09 下午4 43 35" src="https://user-images.githubusercontent.com/998984/153158216-825a7c13-7cfc-410f-92e7-f154449324aa.png">
