### PR TITLE
feat(aws): Support AWS CCM with multiple version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,6 +102,7 @@ require (
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.5
+	github.com/Masterminds/semver v1.5.0
 	github.com/pborman/uuid v1.2.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,7 @@ github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.0.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=

--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -1076,19 +1076,8 @@ func (p *ProviderBase) UpgradeK3sCluster(clusterName, installScript, channel, ve
 		}
 	}()
 
-	c := common.ConvertToCluster(state)
-	masterNodes := make([]types.Node, 0)
-	err = json.Unmarshal(state.MasterNodes, &masterNodes)
-	if err != nil {
-		return err
-	}
-	workerNodes := make([]types.Node, 0)
-	err = json.Unmarshal(state.WorkerNodes, &workerNodes)
-	if err != nil {
-		return err
-	}
-	c.Status.MasterNodes = masterNodes
-	c.Status.WorkerNodes = workerNodes
+	c := common.ConvertToCluster(state, true)
+
 	if installScript != "" {
 		c.InstallScript = installScript
 		state.InstallScript = installScript

--- a/pkg/common/model.go
+++ b/pkg/common/model.go
@@ -233,12 +233,12 @@ func toClusterEvent(state *clusterEvent, schemaID string) apitypes.APIEvent {
 		Object: apitypes.APIObject{
 			Type:   schemaID,
 			ID:     state.Object.ContextName,
-			Object: ConvertToCluster(state.Object),
+			Object: ConvertToCluster(state.Object, false),
 		},
 	}
 }
 
-func ConvertToCluster(state *ClusterState) types.Cluster {
+func ConvertToCluster(state *ClusterState, nodeInfo bool) types.Cluster {
 	c := types.Cluster{
 		Metadata: state.Metadata,
 		SSH:      state.SSH,
@@ -258,6 +258,19 @@ func ConvertToCluster(state *ClusterState) types.Cluster {
 		return c
 	}
 	c.Options = opt
+	if nodeInfo {
+		masterNodes := make([]types.Node, 0)
+		if err := json.Unmarshal(state.MasterNodes, &masterNodes); err != nil {
+			logrus.Errorf("failed to unmarshal master node data for cluster %s/%s, %v", state.Provider, state.Name, err)
+		}
+		workerNodes := make([]types.Node, 0)
+		if err := json.Unmarshal(state.WorkerNodes, &workerNodes); err != nil {
+			logrus.Errorf("failed to unmarshal worker node data for cluster %s/%s, %v", state.Provider, state.Name, err)
+		}
+		c.MasterNodes = masterNodes
+		c.WorkerNodes = workerNodes
+	}
+
 	return c
 }
 


### PR DESCRIPTION
The AWS CCM requires being upgraded after the cluster is upgraded.
So we support deploy compatible CCM version for different k3s version.

Related issue: https://github.com/cnrancher/autok3s/issues/463