### PR TITLE
Fix credential table create problem

### DIFF
--- a/pkg/common/db.go
+++ b/pkg/common/db.go
@@ -114,7 +114,10 @@ func InitStorage(ctx context.Context) error {
 		&ClusterState{},
 		&Template{},
 		&Package{},
-		&Credential{},
+		// TODO
+		// Migrate Credential table will cause create table error when upgrading autok3s from 0.5.x
+		// So we are not migrating this table for now and needs a better upgrade solution in later version.
+		// &Credential{},
 		&Explorer{},
 		&Setting{},
 	); err != nil {


### PR DESCRIPTION
The serve command will failed if autok3s is upgrading from 0.5.2. The root cause is from sqlite driver and gorm and we can't fix for now. So we just don't migrate credentials table for now and will have a better upgrade solution in later version.