### PR TITLE
fix(autok3s): FIx credential table not created

### DIFF
--- a/pkg/common/db.go
+++ b/pkg/common/db.go
@@ -94,6 +94,12 @@ var (
 				is_default               bool,
 				unique (name, provider)
 			);`,
+		`CREATE TABLE IF NOT EXISTS credentials
+			(
+				id integer not null primary key autoincrement,
+				provider TEXT not null,
+				secrets BLOB
+			);`,
 	}
 )
 


### PR DESCRIPTION
Already tested with newly install autok3s and upgraded from v0.5.2. The credential function is ok in both case.