### PR TITLE
fix(autok3s): fix break windows filepath problem

### DIFF
--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 )
 
 const (
@@ -27,7 +27,7 @@ func EnsureFolderExist(path string) error {
 
 // EnsureFileExist ensures file exist.
 func EnsureFileExist(file string) error {
-	if err := EnsureFolderExist(path.Dir(file)); err != nil {
+	if err := EnsureFolderExist(filepath.Dir(file)); err != nil {
 		return err
 	}
 	if _, err := os.Stat(file); os.IsNotExist(err) {


### PR DESCRIPTION
Should use `path/filepath` library to get the dir of file.

Refer to issue: https://github.com/cnrancher/autok3s/issues/520