### PR TITLE
fix(env): Add DOCKER_HOST env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN curl -sSL https://github.com/cnrancher/kube-explorer/releases/download/${KUB
     chmod +x /usr/local/bin/kube-explorer
 
 ENV AUTOK3S_CONFIG /root/.autok3s
+ENV DOCKER_HOST unix:///var/run/docker.sock
 ENV HOME /root
 
 WORKDIR /home/shell

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,8 +12,8 @@ services:
     ports:
     - 8080
     volumes:
-      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
       - $HOME/.autok3s/:$HOME/.autok3s/
     environment:
-    - AUTOK3S_CONFIG=$HOME/.autok3s/
-    - VIRTUAL_HOST=autok3s.vcap.me
+      - AUTOK3S_CONFIG=$HOME/.autok3s/
+      - VIRTUAL_HOST=autok3s.vcap.me


### PR DESCRIPTION
This PR to solve the problem in the usage scenario in #524, adding the `DOCKER_HOST` environment variable to customize the `docker.sock` path

Signed-off-by: Jason-ZW <zhenyang@rancher.com>