### PR TITLE
feat(dashboard): Bump kube-explorer v0.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG TARGETARCH
 ARG TARGETOS
 
 ENV TARGETPLATFORM=${TARGETPLATFORM:-"linux/amd64"} ARCH=${TARGETARCH:-"amd64"} OS=${TARGETOS:-"linux"}
-ENV KUBE_EXPLORER_VERSION=v0.2.13
+ENV KUBE_EXPLORER_VERSION=v0.3.0
 
 RUN zypper -n install curl ca-certificates
 RUN mkdir /home/shell && \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,7 +13,7 @@ SUCCESS_CMD="$REPO version"
 BINLOCATION=${BINLOCATION:-'/usr/local/bin'}
 KUBEEXPLORER_REPO=${KUBEEXPLORER_REPO:-'kube-explorer'}
 KUBEEXPLORER_DOWNLOAD_URL=https://github.com/$OWNER/$KUBEEXPLORER_REPO/releases/download
-KUBEEXPLORER_VERSION=v0.2.13
+KUBEEXPLORER_VERSION=v0.3.0
 SUDO=sudo
 if [ $(id -u) -eq 0 ]; then
     SUDO=


### PR DESCRIPTION
refer to: https://github.com/cnrancher/kube-explorer/releases/tag/v0.3.0

I also checked k3s v1.25.x and v1.26.x. They seem to work fine.

However, strictly speaking, there is only good compatibility with 1.23.x and 1.24.x.