### PR TITLE
feat(provider): skip harvester provider check for historical data

### DIFF
--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -53,6 +53,10 @@ func describeCluster() {
 		logrus.Fatalf("find cluster error %v", err)
 	}
 	for _, state := range result {
+		// TODO skip harvester for historical data, will remove here after harvester provider added back
+		if state.Provider == "harvester" {
+			continue
+		}
 		provider, err := providers.GetProvider(state.Provider)
 		if err != nil {
 			logrus.Errorf("failed to get provider %v: %v", state.Provider, err)

--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -763,6 +763,10 @@ func ListClusters(providerName string) ([]*types.ClusterInfo, error) {
 	kubeCfg := filepath.Join(common.CfgPath, common.KubeCfgFile)
 	clusterList := make([]*types.ClusterInfo, 0)
 	for _, state := range stateList {
+		// TODO skip harvester for historical data, will remove here after harvester provider added back
+		if state.Provider == "harvester" {
+			continue
+		}
 		provider, err := providers.GetProvider(state.Provider)
 		if err != nil {
 			logrus.Errorf("failed to get provider %v: %v", state.Provider, err)

--- a/pkg/server/store/template/store.go
+++ b/pkg/server/store/template/store.go
@@ -68,6 +68,10 @@ func (t *Store) List(apiOp *types.APIRequest, schema *types.APISchema) (types.AP
 			SSH:       template.SSH,
 			IsDefault: template.IsDefault,
 		}
+		// TODO skip harvester for historical data, will remove here after harvester provider added back
+		if template.Provider == "harvester" {
+			continue
+		}
 		provider, err := providers.GetProvider(template.Provider)
 		if err != nil {
 			logrus.Errorf("failed to get provider by name %s: %v", template.Provider, err)


### PR DESCRIPTION
Add skip `harvester` for List/Describe/List template situation to avoid provider register error for user historical data.

Will remove the check after harvester provider added back.