### PR TITLE
fix(autok3s): Fix ssh key create check logic

### DIFF
--- a/pkg/providers/alibaba/alibaba.go
+++ b/pkg/providers/alibaba/alibaba.go
@@ -634,7 +634,7 @@ func (p *Alibaba) getVpcCIDR() (string, error) {
 
 // CreateCheck check create command and flags.
 func (p *Alibaba) CreateCheck() error {
-	if p.KeyPair != "" && (p.SSHKeyPath == "" || p.SSHKeyName == "") {
+	if p.KeyPair != "" && (p.SSHKeyPath == "" && p.SSHKeyName == "") {
 		return fmt.Errorf("[%s] calling preflight error: must set --ssh-key-path or --ssh-key-name with --key-pair %s", p.GetProviderName(), p.KeyPair)
 	}
 

--- a/pkg/providers/aws/aws.go
+++ b/pkg/providers/aws/aws.go
@@ -655,7 +655,7 @@ func (p *Amazon) describeInstances() ([]*ec2.Instance, error) {
 
 // CreateCheck check create command and flags.
 func (p *Amazon) CreateCheck() error {
-	if p.KeypairName != "" && (p.SSHKeyPath == "" || p.SSHKeyName == "") {
+	if p.KeypairName != "" && (p.SSHKeyPath == "" && p.SSHKeyName == "") {
 		return fmt.Errorf("[%s] calling preflight error: must set --ssh-key-path or --ssh-key-name with --keypair-name %s", p.GetProviderName(), p.KeypairName)
 	}
 	masterNum, err := strconv.Atoi(p.Master)

--- a/pkg/providers/tencent/tencent.go
+++ b/pkg/providers/tencent/tencent.go
@@ -623,7 +623,7 @@ func (p *Tencent) CreateCheck() error {
 			return err
 		}
 	}
-	if p.KeypairID != "" && (p.SSHKeyPath == "" || p.SSHKeyName == "") {
+	if p.KeypairID != "" && (p.SSHKeyPath == "" && p.SSHKeyName == "") {
 		return fmt.Errorf("[%s] calling preflight error: --ssh-key-path or --ssh-key-name must set with --key-pair %s", p.GetProviderName(), p.KeypairID)
 	}
 	masterNum, err := strconv.Atoi(p.Master)


### PR DESCRIPTION
Return error when the ssh key path and the ssh key name are both empty.