### PR TITLE
fix(autok3s): Validate empty ssh key input from API

### DIFF
--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -1303,3 +1303,14 @@ func (p *ProviderBase) UpgradeK3sCluster(clusterName, installScript, channel, ve
 
 	return p.Upgrade(&c)
 }
+
+func (p *ProviderBase) ValdiateRequireSSHPrivateKey() error {
+	errStr := "ssh key is require but none of --ssh-key-path or --ssh-key-name is provided"
+	if !common.IsCLI {
+		errStr = "ssh key is require but none of --ssh-key-path, --ssh-key-name or --ssh-key is provided"
+	}
+	if p.SSHKey == "" && p.SSHKeyPath == "" && p.SSHKeyName == "" {
+		return fmt.Errorf(errStr)
+	}
+	return nil
+}

--- a/pkg/providers/alibaba/alibaba.go
+++ b/pkg/providers/alibaba/alibaba.go
@@ -635,8 +635,8 @@ func (p *Alibaba) CreateCheck() error {
 		return err
 	}
 
-	if p.KeyPair != "" && (p.SSHKeyPath == "" && p.SSHKeyName == "") {
-		return fmt.Errorf("[%s] calling preflight error: must set --ssh-key-path or --ssh-key-name with --key-pair %s", p.GetProviderName(), p.KeyPair)
+	if err := p.ValdiateRequireSSHPrivateKey(); p.KeyPair != "" && err != nil {
+		return fmt.Errorf("[%s] calling preflight error: %s with --key-pair %s", p.GetProviderName(), err.Error(), p.KeyPair)
 	}
 	if p.Region != defaultRegion && p.Zone == defaultZoneID && p.VSwitch == "" {
 		return fmt.Errorf("[%s] calling preflight error: must set `--zone` in specified region %s to create default vswitch or set exist `--vswitch` in specified region", p.GetProviderName(), p.Region)

--- a/pkg/providers/aws/aws.go
+++ b/pkg/providers/aws/aws.go
@@ -656,8 +656,8 @@ func (p *Amazon) CreateCheck() error {
 		return err
 	}
 
-	if p.KeypairName != "" && (p.SSHKeyPath == "" && p.SSHKeyName == "") {
-		return fmt.Errorf("[%s] calling preflight error: must set --ssh-key-path or --ssh-key-name with --keypair-name %s", p.GetProviderName(), p.KeypairName)
+	if err := p.ValdiateRequireSSHPrivateKey(); p.KeypairName != "" && err != nil {
+		return fmt.Errorf("[%s] calling preflight error: %s with --keypair-name %s", p.GetProviderName(), err.Error(), p.KeypairName)
 	}
 
 	masterNum, err := strconv.Atoi(p.Master)

--- a/pkg/providers/tencent/tencent.go
+++ b/pkg/providers/tencent/tencent.go
@@ -624,8 +624,8 @@ func (p *Tencent) CreateCheck() error {
 			return err
 		}
 	}
-	if p.KeypairID != "" && (p.SSHKeyPath == "" && p.SSHKeyName == "") {
-		return fmt.Errorf("[%s] calling preflight error: --ssh-key-path or --ssh-key-name must set with --key-pair %s", p.GetProviderName(), p.KeypairID)
+	if err := p.ValdiateRequireSSHPrivateKey(); p.KeypairID != "" && err != nil {
+		return fmt.Errorf("[%s] calling preflight error: %s with --key-pair %s", p.GetProviderName(), err.Error(), p.KeypairID)
 	}
 
 	if p.Region != defaultRegion && p.Zone == defaultZone && p.VpcID == "" {


### PR DESCRIPTION
Different error message will be returned when running as CLI or UI mode.
Refer to comment https://github.com/cnrancher/autok3s/issues/497#issuecomment-1378154176