### PR TITLE
fix(alibaba): Fix failed to upload keypair when creating cluster with multiple nodes

### DIFF
--- a/pkg/providers/alibaba/alibaba.go
+++ b/pkg/providers/alibaba/alibaba.go
@@ -525,7 +525,6 @@ func (p *Alibaba) assembleInstanceStatus(ssh *types.SSH, uploadKeyPair bool, pub
 					return err
 				}
 				v.SSH.SSHPassword = ""
-				ssh.SSHPassword = ""
 			}
 			p.M.Store(status.InstanceId, v)
 			continue


### PR DESCRIPTION
https://github.com/cnrancher/pandaria-test-plan/issues/252#issuecomment-1379847239

The `ssh.SSHPassword` is shared for all instances, if set empty after the first node upload keypair, other nodes will return SSH connect error which causes this issue.