### PR TITLE
fix(provider): fix failed to deploy ccm for K3s v1.25.x

### DIFF
--- a/pkg/providers/alibaba/alibaba.go
+++ b/pkg/providers/alibaba/alibaba.go
@@ -1038,7 +1038,7 @@ func (p *Alibaba) generateInstance(ssh *types.SSH) (*types.Cluster, error) {
 
 	if _, ok := c.Options.(alibaba.Options); ok {
 		if p.CloudControllerManager {
-			c.MasterExtraArgs += " --disable-cloud-controller --no-deploy servicelb,traefik"
+			c.MasterExtraArgs += " --disable-cloud-controller --disable servicelb,traefik"
 		}
 	}
 	c.SSH = *ssh

--- a/pkg/providers/aws/template.go
+++ b/pkg/providers/aws/template.go
@@ -72,6 +72,8 @@ rules:
   - serviceaccounts
   verbs:
   - create
+  - get
+  - list
 - apiGroups:
   - ""
   resources:
@@ -101,6 +103,12 @@ rules:
   - list
   - watch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -149,6 +157,7 @@ spec:
           args:
             - --v=2
             - --cloud-provider=aws
+            - --cluster-cidr={{ .ClusterCIDR }}
 {{- range $index, $args := .ExtraArgs }}
             - {{ $args }}
 {{- end }}

--- a/pkg/providers/google/google.go
+++ b/pkg/providers/google/google.go
@@ -382,7 +382,7 @@ func (p *Google) generateInstance(ssh *types.SSH) (*types.Cluster, error) {
 	}
 	c.ContextName = p.ContextName
 	if p.CloudControllerManager {
-		c.MasterExtraArgs += " --disable-cloud-controller --no-deploy servicelb,traefik,local-storage"
+		c.MasterExtraArgs += " --disable-cloud-controller --disable servicelb,traefik,local-storage"
 	}
 	c.SSH = *ssh
 

--- a/pkg/providers/k3d/flag.go
+++ b/pkg/providers/k3d/flag.go
@@ -247,7 +247,7 @@ func (p *K3d) sharedFlags() []types.Flag {
 			Name:  "master-extra-args",
 			P:     &p.MasterExtraArgs,
 			V:     p.MasterExtraArgs,
-			Usage: "Master extra arguments for k3s installer, wrapped in quotes. e.g.(--master-extra-args '--no-deploy metrics-server'), for more information, please see: https://docs.k3s.io/reference/server-config",
+			Usage: "Master extra arguments for k3s installer, wrapped in quotes. e.g.(--master-extra-args '--disable metrics-server'), for more information, please see: https://docs.k3s.io/reference/server-config",
 		},
 		{
 			Name:  "worker-extra-args",

--- a/pkg/providers/tencent/tencent.go
+++ b/pkg/providers/tencent/tencent.go
@@ -520,7 +520,7 @@ func (p *Tencent) generateInstance(ssh *types.SSH) (*types.Cluster, error) {
 
 	if _, ok := c.Options.(tencent.Options); ok {
 		if p.CloudControllerManager {
-			c.MasterExtraArgs += " --disable-cloud-controller --no-deploy servicelb,traefik"
+			c.MasterExtraArgs += " --disable-cloud-controller --disable servicelb,traefik"
 		}
 	}
 	c.SSH = *ssh


### PR DESCRIPTION
- Using `--disable` instead of `--no-deploy` cause v1.25.x has droped the parameter
- Fix K3sVersion empty error.If user deploy stable/latest version of K3s, this parameter will be empty and ccm manifest won't be deployed

https://github.com/cnrancher/pandaria-test-plan/issues/252#issuecomment-1379841307