### PR TITLE
fix(provider): update join k3d function and rollback logic

### DIFF
--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -1142,10 +1142,18 @@ func (p *ProviderBase) RollbackCluster(rollbackInstance func(ids []string) error
 		if err := rollbackInstance(ids); err != nil {
 			return err
 		}
-		// remove context.
-		if err := common.FileManager.ClearCfgByContext(p.ContextName); err != nil {
-			logrus.Errorf("failed to remove cluster context %s from kube config", p.ContextName)
+
+		state, err := common.DefaultDB.GetCluster(p.Name, p.Provider)
+		if err != nil {
+			return err
 		}
+		if state == nil || state.Status != common.StatusRunning {
+			// remove context.
+			if err := common.FileManager.ClearCfgByContext(p.ContextName); err != nil {
+				logrus.Errorf("failed to remove cluster context %s from kube config", p.ContextName)
+			}
+		}
+
 		p.Logger.Infof("[%s] successfully executed rollback logic", p.Provider)
 	}
 


### PR DESCRIPTION
This PR fix the issue #615 
1. Clear the context config only when the cluster is not running.
2. After creating the k3d cluster, set `node.Rollback` to true, this will enable automatic rollback of the k3d cluster in case of any errors.
3. Fix the logic for generating k3d node name