### PR TITLE
fix(autok3s): Support disabling rollback in API

### DIFF
--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -69,7 +69,7 @@ func NewBaseProvider() *ProviderBase {
 			Worker:        worker,
 			ClusterCidr:   defaultCidr,
 			DockerScript:  dockerInstallScript,
-			Rollback:      true,
+			Rollback:      "true",
 		},
 		Status: types.Status{
 			MasterNodes: make([]types.Node, 0),
@@ -241,7 +241,7 @@ func (p *ProviderBase) GetClusterOptions() []types.Flag {
 			Name:  "rollback",
 			P:     &p.Rollback,
 			V:     p.Rollback,
-			Usage: "Whether to rollback when the K3s cluster installation or join nodes failed.",
+			Usage: "By default, the k3s installation/joining new nodes will rollback if failed. To disable rollback, set it to false.",
 		},
 	}
 
@@ -1131,7 +1131,7 @@ func (p *ProviderBase) Connect(ip string, ssh *types.SSH, c *types.Cluster, getS
 
 // RollbackCluster rollback when error occur.
 func (p *ProviderBase) RollbackCluster(rollbackInstance func(ids []string) error) error {
-	if !p.Rollback {
+	if p.Rollback == "false" {
 		p.Logger.Warnf("[%s] skip executing rollback logic. This is only used for troubleshooting, the instances and cluster is out of control by AutoK3s. Please check K3s error log and uninstalled manually if needed.", p.Provider)
 		return nil
 	}

--- a/pkg/types/autok3s.go
+++ b/pkg/types/autok3s.go
@@ -57,7 +57,7 @@ type Metadata struct {
 	DataStoreCAFileContent   string      `json:"datastore-cafile-content,omitempty" yaml:"datastore-cafile-content,omitempty"`
 	DataStoreCertFileContent string      `json:"datastore-certfile-content,omitempty" yaml:"datastore-certfile-content,omitempty"`
 	DataStoreKeyFileContent  string      `json:"datastore-keyfile-content,omitempty" yaml:"datastore-keyfile-content,omitempty"`
-	Rollback                 bool        `json:"rollback,omitempty" yaml:"rollback,omitempty" gorm:"type:bool"`
+	Rollback                 string      `json:"rollback,omitempty" yaml:"rollback,omitempty" gorm:"type:bool"`
 }
 
 // Status struct for status.


### PR DESCRIPTION
Currently disabling rollback only works in CLI. To change the field to string to support it in API.

The root cause is `MergeConfig` from `pkg/utils/util.go`. If setting rollback to bool `false`, it won't be set to sourceConfig as it is zero value of bool type. By changing it to string to fix it.

Refer to https://github.com/cnrancher/autok3s/issues/504