### PR TITLE
fix(add-ons): minor addon CLI changes

### DIFF
--- a/cmd/addon/args.go
+++ b/cmd/addon/args.go
@@ -1,13 +1,16 @@
 package addon
 
 var (
-	addonFlags = flags{}
+	addonFlags = flags{
+		Values:       map[string]string{},
+		RemoveValues: []string{},
+	}
 )
 
 type flags struct {
-	Name        string
-	Description string
-	FromFile    string
-	Manifest    string
-	Values      map[string]string
+	Name         string
+	Description  string
+	FromFile     string
+	Values       map[string]string
+	RemoveValues []string
 }

--- a/cmd/addon/create.go
+++ b/cmd/addon/create.go
@@ -20,8 +20,7 @@ var (
 
 func init() {
 	createCmd.Flags().StringVar(&addonFlags.Description, "description", addonFlags.Description, "The description of add-on")
-	createCmd.Flags().StringVar(&addonFlags.FromFile, "from", addonFlags.FromFile, "The manifest file path of add-on")
-	createCmd.Flags().StringVar(&addonFlags.Manifest, "manifest", addonFlags.Manifest, "The manifest file content of add-on, need to be base64 encode")
+	createCmd.Flags().StringVarP(&addonFlags.FromFile, "from", "f", addonFlags.FromFile, "The manifest file path of add-on")
 	createCmd.Flags().StringToStringVar(&addonFlags.Values, "set", addonFlags.Values, "Set value to replace parameters defined in manifest")
 }
 
@@ -31,18 +30,18 @@ func CreateCmd() *cobra.Command {
 		if err := common.ValidateName(name); err != nil {
 			return err
 		}
+		if addonFlags.FromFile == "" {
+			return errors.New("must set addon manifest by -f <file-path>")
+		}
 		if addonFlags.FromFile != "" && !utils.IsFileExists(addonFlags.FromFile) {
 			return fmt.Errorf("manifest file %s is not exist", addonFlags.FromFile)
-		}
-		if addonFlags.FromFile == "" && addonFlags.Manifest == "" {
-			return errors.New("must set addon manifest by --from <file-path> or --manifest <base64-encode-manifest>")
 		}
 		return nil
 	}
 
 	createCmd.Run = func(cmd *cobra.Command, args []string) {
 		name := args[0]
-		manifest, err := common.GetManifest(addonFlags.FromFile, addonFlags.Manifest)
+		manifest, err := common.GetManifest(addonFlags.FromFile, "")
 		if err != nil {
 			logrus.Fatalln(err)
 		}

--- a/cmd/addon/create.go
+++ b/cmd/addon/create.go
@@ -3,6 +3,7 @@ package addon
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/cnrancher/autok3s/pkg/common"
 	"github.com/cnrancher/autok3s/pkg/utils"
@@ -41,7 +42,7 @@ func CreateCmd() *cobra.Command {
 
 	createCmd.Run = func(cmd *cobra.Command, args []string) {
 		name := args[0]
-		manifest, err := common.GetManifest(addonFlags.FromFile, "")
+		manifest, err := os.ReadFile(addonFlags.FromFile)
 		if err != nil {
 			logrus.Fatalln(err)
 		}

--- a/cmd/addon/get.go
+++ b/cmd/addon/get.go
@@ -2,11 +2,11 @@ package addon
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/cnrancher/autok3s/pkg/common"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
 )
 
 var (
@@ -24,16 +24,14 @@ func GetCmd() *cobra.Command {
 		if err != nil {
 			logrus.Fatalln(err)
 		}
-		fmt.Println("Name: " + addon.Name)
-		fmt.Println("Description: " + addon.Description)
-		fmt.Println("Manifest: " + string(addon.Manifest))
-		if len(addon.Values) > 0 {
-			values := []string{}
-			for key, value := range addon.Values {
-				values = append(values, fmt.Sprintf("%s=%s", key, value))
-			}
-			fmt.Println("Values: " + strings.Join(values, ","))
+		addonMap := map[string]interface{}{
+			"Name":        addon.Name,
+			"Description": addon.Description,
+			"Manifest":    string(addon.Manifest),
+			"Values":      addon.Values,
 		}
+		data, _ := yaml.Marshal(addonMap)
+		fmt.Println(string(data))
 	}
 	return getCmd
 }

--- a/cmd/addon/ls.go
+++ b/cmd/addon/ls.go
@@ -12,8 +12,9 @@ import (
 
 var (
 	listCmd = &cobra.Command{
-		Use:   "ls",
-		Short: "List all add-on list.",
+		Aliases: []string{"ls"},
+		Use:     "list",
+		Short:   "List all add-on list.",
 	}
 )
 
@@ -24,7 +25,7 @@ func ListCmd() *cobra.Command {
 		table.SetHeaderLine(false)
 		table.SetColumnSeparator("")
 		table.SetAlignment(tablewriter.ALIGN_LEFT)
-		table.SetHeader([]string{"Name", "Description", "Manifest", "Values"})
+		table.SetHeader([]string{"Name", "Description", "Values"})
 
 		addons, err := common.DefaultDB.ListAddon()
 		if err != nil {
@@ -34,7 +35,6 @@ func ListCmd() *cobra.Command {
 			table.Append([]string{
 				addon.Name,
 				addon.Description,
-				strconv.Itoa(len(addon.Manifest)),
 				strconv.Itoa(len(addon.Values)),
 			})
 		}

--- a/cmd/addon/update.go
+++ b/cmd/addon/update.go
@@ -1,10 +1,12 @@
 package addon
 
 import (
-	"bytes"
+	"fmt"
 	"reflect"
 
 	"github.com/cnrancher/autok3s/pkg/common"
+	"github.com/cnrancher/autok3s/pkg/types"
+	"github.com/cnrancher/autok3s/pkg/utils"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -19,52 +21,70 @@ var (
 
 func init() {
 	updateCmd.Flags().StringVar(&addonFlags.Description, "description", addonFlags.Description, "The description of add-on")
-	updateCmd.Flags().StringVar(&addonFlags.FromFile, "from", addonFlags.FromFile, "The manifest file path of add-on")
-	updateCmd.Flags().StringVar(&addonFlags.Manifest, "manifest", addonFlags.Manifest, "The manifest file content of add-on, need to be base64 encode")
+	updateCmd.Flags().StringVarP(&addonFlags.FromFile, "from", "f", addonFlags.FromFile, "The manifest file path of add-on")
 	updateCmd.Flags().StringToStringVar(&addonFlags.Values, "set", addonFlags.Values, "Set value to replace parameters defined in manifest")
+	updateCmd.Flags().StringArrayVar(&addonFlags.RemoveValues, "unset", addonFlags.RemoveValues, "The values of the add-on to unset, will ignore if the value is not present in the list")
 }
 
 func UpdateCmd() *cobra.Command {
+	updateCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if addonFlags.FromFile != "" && !utils.IsFileExists(addonFlags.FromFile) {
+			return fmt.Errorf("manifest file %s is not exist", addonFlags.FromFile)
+		}
+		return nil
+	}
 	updateCmd.Run = func(cmd *cobra.Command, args []string) {
 		name := args[0]
 		addon, err := common.DefaultDB.GetAddon(name)
 		if err != nil {
 			logrus.Fatalln(err)
 		}
-		var manifestFile string
-		manifestContent := string(addon.Manifest)
+		if addon.Values == nil {
+			addon.Values = make(types.StringMap)
+		}
+
+		newAddon := &common.Addon{
+			Name:        addon.Name,
+			Description: addon.Description,
+			Manifest:    addon.Manifest,
+			Values:      map[string]string{},
+		}
+		for k, v := range addon.Values {
+			newAddon.Values[k] = v
+		}
+
 		if addonFlags.FromFile != "" {
-			manifestFile = addonFlags.FromFile
-		} else if addonFlags.Manifest != "" {
-			manifestContent = addonFlags.Manifest
-		}
-
-		manifestString, err := common.GetManifest(manifestFile, manifestContent)
-		if err != nil {
-			logrus.Fatalln(err)
-		}
-		manifest := []byte(manifestString)
-
-		isChanged := false
-		if addonFlags.Description != "" && addonFlags.Description != addon.Description {
-			addon.Description = addonFlags.Description
-			isChanged = true
-		}
-
-		if !bytes.Equal(manifest, addon.Manifest) {
-			addon.Manifest = manifest
-			isChanged = true
-		}
-
-		if !reflect.DeepEqual(addonFlags.Values, addon.Values) {
-			addon.Values = addonFlags.Values
-			isChanged = true
-		}
-
-		if isChanged {
-			if err := common.DefaultDB.SaveAddon(addon); err != nil {
-				logrus.Fatalln(err)
+			manifestString, err := common.GetManifest(addonFlags.FromFile, "")
+			if err != nil {
+				logrus.Error(err)
+				return
 			}
+			newAddon.Manifest = []byte(manifestString)
+		}
+
+		if addonFlags.Description != "" {
+			newAddon.Description = addonFlags.Description
+		}
+
+		// unset values
+		for _, v := range addonFlags.RemoveValues {
+			if _, ok := newAddon.Values[v]; ok {
+				delete(newAddon.Values, v)
+			}
+		}
+		// re-set values
+		for k, v := range addonFlags.Values {
+			newAddon.Values[k] = v
+		}
+
+		if !reflect.DeepEqual(addon, newAddon) {
+			if err := common.DefaultDB.SaveAddon(newAddon); err != nil {
+				logrus.Error(err)
+				return
+			}
+			cmd.Println("add-on updated")
+		} else {
+			cmd.Println("add-on is not changed")
 		}
 	}
 

--- a/cmd/addon/update.go
+++ b/cmd/addon/update.go
@@ -2,6 +2,7 @@ package addon
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 
 	"github.com/cnrancher/autok3s/pkg/common"
@@ -54,7 +55,7 @@ func UpdateCmd() *cobra.Command {
 		}
 
 		if addonFlags.FromFile != "" {
-			manifestString, err := common.GetManifest(addonFlags.FromFile, "")
+			manifestString, err := os.ReadFile(addonFlags.FromFile)
 			if err != nil {
 				logrus.Error(err)
 				return

--- a/pkg/common/manifest.go
+++ b/pkg/common/manifest.go
@@ -3,29 +3,14 @@ package common
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
-	"github.com/cnrancher/autok3s/pkg/utils"
 	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/strvals"
 
 	"k8s.io/apimachinery/pkg/util/validation"
 )
-
-func GetManifest(manifestFile, manifestContent string) (string, error) {
-	if manifestFile != "" {
-		fileByte, err := os.ReadFile(manifestFile)
-		if err != nil {
-			return "", err
-		}
-		return string(fileByte), nil
-	} else if manifestContent != "" {
-		return utils.StringSupportBase64(manifestContent), nil
-	}
-	return "", errors.New("can't get manifest with empty manifest file or content")
-}
 
 func GenerateValues(setValues map[string]string, defaultValues map[string]string) (map[string]interface{}, error) {
 	values := []string{}

--- a/pkg/server/store/addon/store.go
+++ b/pkg/server/store/addon/store.go
@@ -27,19 +27,14 @@ func (a *Store) Create(apiOp *types.APIRequest, schema *types.APISchema, data ty
 	if err := common.ValidateName(input.Name); err != nil {
 		return types.APIObject{}, err
 	}
-	if input.Manifest == nil {
-		return types.APIObject{}, errors.New("manifest file or manifest file content cannot be empty")
-	}
-
-	manifest, err := common.GetManifest("", string(input.Manifest))
-	if err != nil {
-		return types.APIObject{}, err
+	if input.Manifest == nil || len(input.Manifest) == 0 {
+		return types.APIObject{}, errors.New("manifest file content cannot be empty")
 	}
 
 	addon := &common.Addon{
 		Name:        input.Name,
 		Description: input.Description,
-		Manifest:    []byte(manifest),
+		Manifest:    input.Manifest,
 		Values:      input.Values,
 	}
 	err = common.DefaultDB.SaveAddon(addon)
@@ -91,16 +86,10 @@ func (a *Store) Update(apiOp *types.APIRequest, schema *types.APISchema, data ty
 		return types.APIObject{}, err
 	}
 
-	manifestContent := addon.Manifest
-	if input.Manifest != nil {
-		manifestContent = input.Manifest
+	manifest := addon.Manifest
+	if len(input.Manifest) != 0 {
+		manifest = input.Manifest
 	}
-
-	manifestString, err := common.GetManifest("", string(manifestContent))
-	if err != nil {
-		return types.APIObject{}, err
-	}
-	manifest := []byte(manifestString)
 
 	isChanged := false
 	if input.Description != "" && input.Description != addon.Description {


### PR DESCRIPTION
- Remove --manifest args for create/update in cli as it's not useful.
- Add --unset args for update command to delete values of add-on.
- Add shortcut -f for --from args.
- The list command won't return manifest count.
- The get command will return the yaml format of addon.
