### PR TITLE
change deploy add-on manifests folder and add unknown cluster status

### DIFF
--- a/hack/make-rules/autok3s.sh
+++ b/hack/make-rules/autok3s.sh
@@ -9,7 +9,7 @@ CURR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 # The root of the autok3s directory
 ROOT_DIR="${CURR_DIR}"
 CROSS=${CROSS:-}
-UI_VERSION="v0.8.0"
+UI_VERSION="v0.9.0-rc2"
 
 source "${ROOT_DIR}/hack/lib/init.sh"
 source "${CURR_DIR}/hack/lib/constant.sh"

--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -995,6 +995,11 @@ func ListClusters(providerName string) ([]*types.ClusterInfo, error) {
 		}
 		isExist, _, err := provider.IsClusterExist()
 		if err != nil {
+			info := provider.GetCluster("")
+			info.Status = common.StatusUnknown
+			info.Master = state.Master
+			info.Worker = state.Worker
+			clusterList = append(clusterList, info)
 			logrus.Errorf("failed to check provider %s cluster %s exist, got error: %v ", state.Provider, state.Name, err)
 			continue
 		}

--- a/pkg/cluster/base.go
+++ b/pkg/cluster/base.go
@@ -428,6 +428,10 @@ func (p *ProviderBase) InitCluster(options interface{}, deployPlugins func() []s
 		}
 	}
 
+	if _, err := p.execute(&c.MasterNodes[0], []string{fmt.Sprintf("mkdir -p %s", common.K3sManifestsDir)}...); err != nil {
+		return err
+	}
+
 	if deployPlugins != nil {
 		// install additional manifests to the current cluster.
 		extraManifests := deployPlugins()

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -16,7 +16,7 @@ const (
 	// KubeCfgTempName default temp kube config file name prefix.
 	KubeCfgTempName = "autok3s-temp-*"
 	// K3sManifestsDir k3s manifests dir.
-	K3sManifestsDir = "/var/lib/rancher/k3s/server/manifests"
+	K3sManifestsDir = "/var/lib/rancher/k3s/server/manifests/autok3s"
 	// MasterInstanceName master instance name.
 	MasterInstanceName = "autok3s.%s.master"
 	// WorkerInstanceName worker instance name.

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -35,6 +35,8 @@ const (
 	StatusUpgrading = "Upgrading"
 	// StatusRemoving instance removing status.
 	StatusRemoving = "Removing"
+	// StatusUnknown instance unknown status
+	StatusUnknown = "Unknown"
 	// UsageInfoTitle usage info title.
 	UsageInfoTitle = "=========================== Prompt Info ==========================="
 	// UsageContext usage info context.


### PR DESCRIPTION
- change deploy add-on manifests to autok3s folder
- If the cloud provider can't get the instance properly, the cluster item will skip the list. Add unknown status for these kinds of clusters.