### PR TITLE
fix(autok3s): Upgrade golang builder to v1.20.8

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -3,7 +3,7 @@
     "disable-all": true,
     "enable": [
       "govet",
-      "golint",
+      "revive",
       "goimports",
       "misspell",
       "ineffassign",

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,12 +1,19 @@
-FROM registry.suse.com/bci/golang:1.19
+# FROM registry.suse.com/bci/golang:1.20
+FROM registry.suse.com/bci/bci-base:latest
 ARG PROXY
 ARG GOPROXY
-RUN zypper -n install netcat wget curl gawk
+ARG ARCH=amd64
+ARG GO_VERSION=1.20.8
+RUN curl -sSL https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz -o /tmp/go.tar.gz \
+    && rm -rf /usr/local/go && tar -C /usr/local -xzf /tmp/go.tar.gz \
+    && /usr/local/go/bin/go version
+ENV GOPATH=/go PATH=/go/bin:/usr/local/go/bin:/root/go/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+RUN zypper -n install netcat wget curl gawk git make
 RUN zypper install -y -f docker
 ## install golangci-lint
 RUN if [ "$(go env GOARCH)" = "amd64" ]; then \
     export HTTPS_PROXY=${PROXY}; \
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.50.1; \
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.54.2; \
     golangci-lint --version; \
     fi
 ## install mockgen

--- a/cmd/airgap/import.go
+++ b/cmd/airgap/import.go
@@ -19,10 +19,8 @@ var (
 			if err := cobra.MaximumNArgs(2)(cmd, args); err != nil {
 				return err
 			}
-			if err := cobra.MinimumNArgs(1)(cmd, args); err != nil {
-				return err
-			}
-			return nil
+
+			return cobra.MinimumNArgs(1)(cmd, args)
 		},
 		RunE: importFunc,
 	}

--- a/cmd/airgap/ls.go
+++ b/cmd/airgap/ls.go
@@ -24,10 +24,10 @@ func init() {
 	listCmd.Flags().BoolVarP(&airgapFlags.isJSON, "json", "j", airgapFlags.isJSON, "json output")
 }
 
-func list(cmd *cobra.Command, args []string) error {
+func list(cmd *cobra.Command, _ []string) error {
 	pkgs, err := common.DefaultDB.ListPackages(nil)
 	if err != nil {
-		return errors.Wrap(err, "failed to list airgap packages.")
+		return errors.Wrap(err, "failed to list airgap packages")
 	}
 	if airgapFlags.isJSON {
 		data, err := json.Marshal(pkgs)

--- a/cmd/airgap/update_script.go
+++ b/cmd/airgap/update_script.go
@@ -17,7 +17,7 @@ var (
 	}
 )
 
-func updateInstallScript(cmd *cobra.Command, args []string) error {
+func updateInstallScript(cmd *cobra.Command, _ []string) error {
 	buff := bytes.NewBuffer([]byte{})
 	if err := settings.GetScriptFromSource(buff); err != nil {
 		return err

--- a/cmd/sshkey/export.go
+++ b/cmd/sshkey/export.go
@@ -26,7 +26,7 @@ func init() {
 	exportCmd.Flags().StringVarP(&sshKeyFlags.OutputPath, "output", "o", ".", "The path to write key pair files, will write to id_rsa, id_rsa.pub and pub.cert under the output path")
 }
 
-func validateFiles(cmd *cobra.Command, args []string) error {
+func validateFiles(_ *cobra.Command, args []string) error {
 	if err := pathExists(sshKeyFlags.OutputPath); err != nil {
 		return err
 	}
@@ -51,11 +51,8 @@ func validateFiles(cmd *cobra.Command, args []string) error {
 		}
 		toValidate = append(toValidate, filename)
 	}
-	if err := pathsNotExists(sshKeyFlags.OutputPath, toValidate...); err != nil {
-		return err
-	}
 
-	return nil
+	return pathsNotExists(sshKeyFlags.OutputPath, toValidate...)
 }
 
 func export(cmd *cobra.Command, args []string) error {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,11 @@
 module github.com/cnrancher/autok3s
 
-go 1.19
+go 1.20
+
+replace (
+	go4.org/unsafe/assume-no-moving-gc => go4.org/unsafe/assume-no-moving-gc v0.0.0-20230525183740-e7c30c78aeb2
+	inet.af/netaddr => inet.af/netaddr v0.0.0-20230525184311-b8eac61e914a
+)
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.5
@@ -170,7 +175,7 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	go4.org/intern v0.0.0-20211027215823-ae77deb06f29 // indirect
-	go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 // indirect
+	go4.org/unsafe/assume-no-moving-gc v0.0.0-20230525183740-e7c30c78aeb2 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1107,9 +1107,8 @@ go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go4.org/intern v0.0.0-20211027215823-ae77deb06f29 h1:UXLjNohABv4S58tHmeuIZDO6e3mHpW2Dx33gaNt03LE=
 go4.org/intern v0.0.0-20211027215823-ae77deb06f29/go.mod h1:cS2ma+47FKrLPdXFpr7CuxiTW3eyJbWew4qx0qtQWDA=
-go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
-go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 h1:FyBZqvoA/jbNzuAWLQE2kG820zMAkcilx6BMjGbL/E4=
-go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
+go4.org/unsafe/assume-no-moving-gc v0.0.0-20230525183740-e7c30c78aeb2 h1:WJhcL4p+YeDxmZWg141nRm7XC8IDmhz7lk5GpadO1Sg=
+go4.org/unsafe/assume-no-moving-gc v0.0.0-20230525183740-e7c30c78aeb2/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
 golang.org/x/crypto v0.0.0-20171113213409-9f005a07e0d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181009213950-7c1a557ab941/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -1639,8 +1638,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-inet.af/netaddr v0.0.0-20220811202034-502d2d690317 h1:U2fwK6P2EqmopP/hFLTOAjWTki0qgd4GMJn5X8wOleU=
-inet.af/netaddr v0.0.0-20220811202034-502d2d690317/go.mod h1:OIezDfdzOgFhuw4HuWapWq2e9l0H9tK4F1j+ETRtF3k=
+inet.af/netaddr v0.0.0-20230525184311-b8eac61e914a h1:1XCVEdxrvL6c0TGOhecLuB7U9zYNdxZEjvOqJreKZiM=
+inet.af/netaddr v0.0.0-20230525184311-b8eac61e914a/go.mod h1:e83i32mAQOW1LAqEIweALsuK2Uw4mhQadA5r7b0Wobo=
 k8s.io/api v0.18.0/go.mod h1:q2HRQkfDzHMBZL9l/y9rH63PkQl4vae0xRT+8prbrK8=
 k8s.io/api v0.20.1/go.mod h1:KqwcCVogGxQY3nBlRpwt+wpAMF/KjaCc7RpywacvqUo=
 k8s.io/api v0.20.4/go.mod h1:++lNL1AJMkDymriNniQsWRkMDzRaX2Y/POTUi8yvqYQ=

--- a/hack/lib/lint.sh
+++ b/hack/lib/lint.sh
@@ -34,7 +34,7 @@ function autok3s::lint::lint() {
 
   if autok3s::lint::validate; then
     for path in "$@"; do
-      golangci-lint run "${path}"
+      golangci-lint -v run "${path}"
     done
   else
     autok3s::log::warn "no golangci-lint available, using go fmt/vet instead"

--- a/pkg/airgap/download.go
+++ b/pkg/airgap/download.go
@@ -249,7 +249,7 @@ func (d *downloader) validateVersion() error {
 	downloadURL := fmt.Sprintf("%s/%s", sourceURL, imageListFilename)
 	resp, err := doRequestWithCtx(d.ctx, http.MethodGet, downloadURL, nil)
 	if err != nil {
-		return errors.Wrapf(err, "failed to download image list of k3s version %s, this version may be not validated.", d.pkg.K3sVersion)
+		return errors.Wrapf(err, "failed to download image list of k3s version %s, this version may be not validated", d.pkg.K3sVersion)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/pkg/common/log.go
+++ b/pkg/common/log.go
@@ -82,10 +82,8 @@ func MoveLogs() error {
 		if err := os.MkdirAll(filepath.Join(newRoot, rel), 0755); err != nil {
 			return err
 		}
-		if err := os.Rename(path, GetClusterLogFilePath(rel)); err != nil {
-			return err
-		}
-		return nil
+
+		return os.Rename(path, GetClusterLogFilePath(rel))
 	}); err != nil {
 		return err
 	}

--- a/pkg/hosts/dialer/docker.go
+++ b/pkg/hosts/dialer/docker.go
@@ -183,7 +183,7 @@ func (d *DockerShell) Terminal() error {
 }
 
 // OpenTerminal open docker websocket terminal.
-func (d *DockerShell) OpenTerminal(win hosts.ShellWindowSize) error {
+func (d *DockerShell) OpenTerminal(_ hosts.ShellWindowSize) error {
 	return d.ExecStart(false)
 }
 
@@ -443,6 +443,6 @@ func (d *DockerShell) ChangeWindowSize(win hosts.ShellWindowSize) error {
 }
 
 // Write write implement.
-func (d *DockerShell) Write(b []byte) error {
+func (d *DockerShell) Write(_ []byte) error {
 	return nil
 }

--- a/pkg/hosts/dialer/ssh.go
+++ b/pkg/hosts/dialer/ssh.go
@@ -227,7 +227,7 @@ type SSHShell struct {
 	dialer  *SSHDialer
 }
 
-func (d *SSHShell) Write(b []byte) error {
+func (d *SSHShell) Write(_ []byte) error {
 	return nil
 }
 

--- a/pkg/providers/aws/aws.go
+++ b/pkg/providers/aws/aws.go
@@ -271,10 +271,7 @@ func (p *Amazon) SetConfig(config []byte) error {
 }
 
 func (p *Amazon) rollbackInstance(ids []string) error {
-	if err := p.terminateInstance(ids); err != nil {
-		return err
-	}
-	return nil
+	return p.terminateInstance(ids)
 }
 
 func (p *Amazon) generateInstance(ssh *types.SSH) (*types.Cluster, error) {

--- a/pkg/providers/k3d/k3d.go
+++ b/pkg/providers/k3d/k3d.go
@@ -241,12 +241,12 @@ func (p *K3d) JoinCheck() error {
 }
 
 // GenerateMasterExtraArgs generates K3S master extra args.
-func (p *K3d) GenerateMasterExtraArgs(cluster *types.Cluster, master types.Node) string {
+func (p *K3d) GenerateMasterExtraArgs(_ *types.Cluster, _ types.Node) string {
 	return ""
 }
 
 // GenerateWorkerExtraArgs generates K3S worker extra args.
-func (p *K3d) GenerateWorkerExtraArgs(cluster *types.Cluster, worker types.Node) string {
+func (p *K3d) GenerateWorkerExtraArgs(_ *types.Cluster, _ types.Node) string {
 	return ""
 }
 
@@ -340,7 +340,7 @@ func (p *K3d) obtainKubeCfg() (kubeCfg, ip string, err error) {
 	return
 }
 
-func (p *K3d) createK3d(ssh *types.SSH) (*types.Cluster, error) {
+func (p *K3d) createK3d(_ *types.SSH) (*types.Cluster, error) {
 	masterNum, _ := strconv.Atoi(p.Master)
 	workerNum, _ := strconv.Atoi(p.Worker)
 

--- a/pkg/providers/native/native.go
+++ b/pkg/providers/native/native.go
@@ -68,13 +68,13 @@ func (p *Native) GenerateManifest() []string {
 }
 
 // GenerateMasterExtraArgs generates K3S master extra args.
-func (p *Native) GenerateMasterExtraArgs(cluster *types.Cluster, master types.Node) string {
+func (p *Native) GenerateMasterExtraArgs(_ *types.Cluster, _ types.Node) string {
 	// no need to support.
 	return ""
 }
 
 // GenerateWorkerExtraArgs generates K3S worker extra args.
-func (p *Native) GenerateWorkerExtraArgs(cluster *types.Cluster, worker types.Node) string {
+func (p *Native) GenerateWorkerExtraArgs(_ *types.Cluster, _ types.Node) string {
 	// no need to support.
 	return ""
 }
@@ -414,7 +414,7 @@ func (p *Native) getInstanceNodes() ([]types.Node, error) {
 	return nodes, nil
 }
 
-func (p *Native) uninstallCluster(f bool) (string, error) {
+func (p *Native) uninstallCluster(_ bool) (string, error) {
 	// don't uninstall cluster if it's not handled by autok3s
 	if p.Status.Standalone {
 		p.Logger.Infof("[%s] cluster %s is not handled by autok3s, we won't uninstall the cluster automatically", p.GetProviderName(), p.Name)
@@ -428,6 +428,6 @@ func (p *Native) uninstallCluster(f bool) (string, error) {
 	return p.ContextName, nil
 }
 
-func (p *Native) isInstanceRunning(state string) bool {
+func (p *Native) isInstanceRunning(_ string) bool {
 	return true
 }

--- a/pkg/providers/tencent/tencent.go
+++ b/pkg/providers/tencent/tencent.go
@@ -916,7 +916,7 @@ func (p *Tencent) describeVpcTaskResult(taskID uint64) error {
 	request := vpc.NewDescribeTaskResultRequest()
 	request.TaskId = tencentCommon.Uint64Ptr(taskID)
 
-	if err := wait.ExponentialBackoff(common.Backoff, func() (bool, error) {
+	return wait.ExponentialBackoff(common.Backoff, func() (bool, error) {
 		response, err := p.v.DescribeTaskResult(request)
 		if err != nil {
 			return false, nil
@@ -932,10 +932,7 @@ func (p *Tencent) describeVpcTaskResult(taskID uint64) error {
 		}
 
 		return true, nil
-	}); err != nil {
-		return err
-	}
-	return nil
+	})
 }
 
 func (p *Tencent) getInstanceStatus(aimStatus string) error {

--- a/pkg/server/proxy/k8s_proxy.go
+++ b/pkg/server/proxy/k8s_proxy.go
@@ -21,7 +21,7 @@ func NewK8sProxy() http.Handler {
 
 type errorResponder struct{}
 
-func (r *errorResponder) Error(w http.ResponseWriter, req *http.Request, err error) {
+func (r *errorResponder) Error(w http.ResponseWriter, _ *http.Request, err error) {
 	logrus.Errorf("Error while proxying request: %v", err)
 	http.Error(w, err.Error(), http.StatusInternalServerError)
 }

--- a/pkg/server/store/addon/store.go
+++ b/pkg/server/store/addon/store.go
@@ -44,7 +44,7 @@ func (a *Store) Create(apiOp *types.APIRequest, schema *types.APISchema, data ty
 	return a.ByID(apiOp, schema, addon.Name)
 }
 
-func (a *Store) List(apiOp *types.APIRequest, schema *types.APISchema) (types.APIObjectList, error) {
+func (a *Store) List(_ *types.APIRequest, schema *types.APISchema) (types.APIObjectList, error) {
 	result := types.APIObjectList{}
 	list, err := common.DefaultDB.ListAddon()
 	if err != nil {
@@ -62,7 +62,7 @@ func (a *Store) List(apiOp *types.APIRequest, schema *types.APISchema) (types.AP
 	return result, nil
 }
 
-func (a *Store) ByID(apiOp *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
+func (a *Store) ByID(_ *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
 	addon, err := common.DefaultDB.GetAddon(id)
 	if err != nil {
 		return types.APIObject{}, err
@@ -115,11 +115,11 @@ func (a *Store) Update(apiOp *types.APIRequest, schema *types.APISchema, data ty
 	return a.ByID(apiOp, schema, id)
 }
 
-func (a *Store) Delete(apiOp *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
+func (a *Store) Delete(_ *types.APIRequest, _ *types.APISchema, id string) (types.APIObject, error) {
 	err := common.DefaultDB.DeleteAddon(id)
 	return types.APIObject{}, err
 }
 
-func (a *Store) Watch(apiOp *types.APIRequest, schema *types.APISchema, wr types.WatchRequest) (chan types.APIEvent, error) {
+func (a *Store) Watch(apiOp *types.APIRequest, schema *types.APISchema, _ types.WatchRequest) (chan types.APIEvent, error) {
 	return common.DefaultDB.Watch(apiOp, schema), nil
 }

--- a/pkg/server/store/cluster/action.go
+++ b/pkg/server/store/cluster/action.go
@@ -62,7 +62,7 @@ func LinkCluster(request *types.APIRequest) (types.APIObject, error) {
 
 type join struct{}
 
-func (j join) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+func (j join) ServeHTTP(_ http.ResponseWriter, req *http.Request) {
 	apiRequest := types.GetAPIContext(req.Context())
 	clusterID := apiRequest.Name
 	if clusterID == "" {
@@ -137,7 +137,7 @@ func (j join) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	apiRequest.WriteResponse(http.StatusOK, types.APIObject{})
 }
 
-func nodesHandler(apiOp *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
+func nodesHandler(_ *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
 	state, err := common.DefaultDB.GetClusterByID(id)
 	if err != nil || state == nil {
 		// find from failed cluster.
@@ -163,7 +163,7 @@ func nodesHandler(apiOp *types.APIRequest, schema *types.APISchema, id string) (
 
 type explorer struct{}
 
-func (e explorer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+func (e explorer) ServeHTTP(_ http.ResponseWriter, req *http.Request) {
 	apiRequest := types.GetAPIContext(req.Context())
 	clusterID := apiRequest.Name
 	if clusterID == "" {
@@ -198,7 +198,7 @@ func (e explorer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 type downloadKubeconfig struct{}
 
-func (d downloadKubeconfig) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+func (d downloadKubeconfig) ServeHTTP(_ http.ResponseWriter, req *http.Request) {
 	apiRequest := types.GetAPIContext(req.Context())
 	vars := mux.Vars(req)
 	clusterID := vars["name"]

--- a/pkg/server/store/cluster/store.go
+++ b/pkg/server/store/cluster/store.go
@@ -24,7 +24,7 @@ type Store struct {
 }
 
 // Create creates cluster based on the request data.
-func (c *Store) Create(apiOp *types.APIRequest, schema *types.APISchema, data types.APIObject) (types.APIObject, error) {
+func (c *Store) Create(_ *types.APIRequest, schema *types.APISchema, data types.APIObject) (types.APIObject, error) {
 	providerName := data.Data().String("provider")
 	b, err := json.Marshal(data.Data())
 	if err != nil {
@@ -83,7 +83,7 @@ func (c *Store) List(apiOp *types.APIRequest, schema *types.APISchema) (types.AP
 }
 
 // ByID returns cluster by ID.
-func (c *Store) ByID(apiOp *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
+func (c *Store) ByID(_ *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
 	state, err := common.DefaultDB.GetClusterByID(id)
 	if err != nil || state == nil {
 		return types.APIObject{}, apierror.NewAPIError(validation.NotFound, fmt.Sprintf("cluster %s is not found, got error: %v", id, err))
@@ -121,7 +121,7 @@ func (c *Store) ByID(apiOp *types.APIRequest, schema *types.APISchema, id string
 }
 
 // Delete deletes cluster by ID.
-func (c *Store) Delete(apiOp *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
+func (c *Store) Delete(_ *types.APIRequest, _ *types.APISchema, id string) (types.APIObject, error) {
 	state, err := common.DefaultDB.GetClusterByID(id)
 	if err != nil || state == nil {
 		return types.APIObject{}, apierror.NewAPIError(validation.NotFound, fmt.Sprintf("cluster %s is not found, got error: %v", id, err))
@@ -156,7 +156,7 @@ func (c *Store) Delete(apiOp *types.APIRequest, schema *types.APISchema, id stri
 }
 
 // Watch watches cluster change event.
-func (c *Store) Watch(apiOp *types.APIRequest, schema *types.APISchema, w types.WatchRequest) (chan types.APIEvent, error) {
+func (c *Store) Watch(apiOp *types.APIRequest, schema *types.APISchema, _ types.WatchRequest) (chan types.APIEvent, error) {
 	result := make(chan types.APIEvent)
 	data := common.DefaultDB.Watch(apiOp, schema)
 	go func() {

--- a/pkg/server/store/credential/schema.go
+++ b/pkg/server/store/credential/schema.go
@@ -61,7 +61,7 @@ func Formatter(request *types.APIRequest, resource *types.RawResource) {
 	resource.Schema.LinkHandlers = map[string]http.Handler{"forms": http.HandlerFunc(formsHandler)}
 }
 
-func formsHandler(w http.ResponseWriter, r *http.Request) {
+func formsHandler(_ http.ResponseWriter, r *http.Request) {
 	result := types.APIObjectList{}
 	apiContext := types.GetAPIContext(r.Context())
 

--- a/pkg/server/store/credential/store.go
+++ b/pkg/server/store/credential/store.go
@@ -22,7 +22,7 @@ type Store struct {
 }
 
 // ByID returns credential by ID.
-func (cred *Store) ByID(apiOp *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
+func (cred *Store) ByID(_ *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
 	credID, err := strconv.Atoi(id)
 	if err != nil {
 		return types.APIObject{}, apierror.NewAPIError(validation.InvalidOption, fmt.Sprintf("invalid id %s", id))
@@ -47,7 +47,7 @@ func (cred *Store) ByID(apiOp *types.APIRequest, schema *types.APISchema, id str
 }
 
 // List returns credentials as list.
-func (cred *Store) List(apiOp *types.APIRequest, schema *types.APISchema) (types.APIObjectList, error) {
+func (cred *Store) List(_ *types.APIRequest, schema *types.APISchema) (types.APIObjectList, error) {
 	credList, err := common.DefaultDB.ListCredential()
 	if err != nil {
 		return types.APIObjectList{}, err
@@ -69,7 +69,7 @@ func (cred *Store) List(apiOp *types.APIRequest, schema *types.APISchema) (types
 }
 
 // Create creates credential based on the request data.
-func (cred *Store) Create(apiOp *types.APIRequest, schema *types.APISchema, data types.APIObject) (types.APIObject, error) {
+func (cred *Store) Create(_ *types.APIRequest, schema *types.APISchema, data types.APIObject) (types.APIObject, error) {
 	secrets := data.Data().Map("secrets")
 	p := data.Data().String("provider")
 	c, err := generateCredential(secrets, p)
@@ -112,7 +112,7 @@ func (cred *Store) Update(apiOp *types.APIRequest, schema *types.APISchema, data
 }
 
 // Delete deletes credential by ID.
-func (cred *Store) Delete(apiOp *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
+func (cred *Store) Delete(_ *types.APIRequest, _ *types.APISchema, id string) (types.APIObject, error) {
 	credID, err := strconv.Atoi(id)
 	if err != nil {
 		return types.APIObject{}, apierror.NewAPIError(validation.InvalidOption, fmt.Sprintf("invalid id %s", id))

--- a/pkg/server/store/explorer/store.go
+++ b/pkg/server/store/explorer/store.go
@@ -18,7 +18,7 @@ type Store struct {
 }
 
 // ByID returns explorer setting by ID.
-func (s *Store) ByID(apiOp *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
+func (s *Store) ByID(_ *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
 	exp, err := common.DefaultDB.GetExplorer(id)
 	if err != nil {
 		return types.APIObject{}, err
@@ -34,7 +34,7 @@ func (s *Store) ByID(apiOp *types.APIRequest, schema *types.APISchema, id string
 }
 
 // List returns all K3s explorer settings
-func (s *Store) List(apiOp *types.APIRequest, schema *types.APISchema) (types.APIObjectList, error) {
+func (s *Store) List(_ *types.APIRequest, schema *types.APISchema) (types.APIObjectList, error) {
 	result := types.APIObjectList{}
 	expList, err := common.DefaultDB.ListExplorer()
 	if err != nil {
@@ -51,7 +51,7 @@ func (s *Store) List(apiOp *types.APIRequest, schema *types.APISchema) (types.AP
 }
 
 // Watch explorer settings change
-func (s *Store) Watch(apiOp *types.APIRequest, schema *types.APISchema, w types.WatchRequest) (chan types.APIEvent, error) {
+func (s *Store) Watch(apiOp *types.APIRequest, schema *types.APISchema, _ types.WatchRequest) (chan types.APIEvent, error) {
 	return common.DefaultDB.Watch(apiOp, schema), nil
 }
 

--- a/pkg/server/store/kubectl/store.go
+++ b/pkg/server/store/kubectl/store.go
@@ -18,7 +18,7 @@ type Store struct {
 }
 
 // List returns kubectl contexts.
-func (k *Store) List(apiOp *types.APIRequest, schema *types.APISchema) (types.APIObjectList, error) {
+func (k *Store) List(_ *types.APIRequest, schema *types.APISchema) (types.APIObjectList, error) {
 	result := types.APIObjectList{}
 	kubeCfg := filepath.Join(common.CfgPath, common.KubeCfgFile)
 	clientConfig, err := clientcmd.LoadFromFile(kubeCfg)

--- a/pkg/server/store/pkg/schema.go
+++ b/pkg/server/store/pkg/schema.go
@@ -27,7 +27,7 @@ var (
 	}
 )
 
-func Format(request *types.APIRequest, resource *types.RawResource) {
+func Format(_ *types.APIRequest, resource *types.RawResource) {
 	linksToKeep := map[string]struct{}{}
 	actionsToKeep := map[string]struct{}{}
 	switch common.State(resource.APIObject.Data().String("state")) {
@@ -57,7 +57,7 @@ func CollectionFormat(request *types.APIRequest, collection *types.GenericCollec
 	collection.AddAction(request, "update-install-script")
 }
 
-func importHandler(w http.ResponseWriter, r *http.Request) {
+func importHandler(_ http.ResponseWriter, r *http.Request) {
 	apiContext := types.GetAPIContext(r.Context())
 	name := apiContext.Query.Get("name")
 	if name == "" {

--- a/pkg/server/store/pkg/store.go
+++ b/pkg/server/store/pkg/store.go
@@ -21,12 +21,12 @@ type Store struct {
 	empty.Store
 }
 
-func (e *Store) Delete(apiOp *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
+func (e *Store) Delete(_ *types.APIRequest, _ *types.APISchema, id string) (types.APIObject, error) {
 	defer airgap.RemovePackage(id)
 	return types.APIObject{}, common.DefaultDB.DeletePackage(id)
 }
 
-func (e *Store) ByID(apiOp *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
+func (e *Store) ByID(_ *types.APIRequest, _ *types.APISchema, id string) (types.APIObject, error) {
 	rtn, err := common.DefaultDB.ListPackages(&id)
 	if err != nil {
 		return types.APIObject{}, err
@@ -35,7 +35,7 @@ func (e *Store) ByID(apiOp *types.APIRequest, schema *types.APISchema, id string
 	return *obj, nil
 }
 
-func (e *Store) List(apiOp *types.APIRequest, schema *types.APISchema) (types.APIObjectList, error) {
+func (e *Store) List(_ *types.APIRequest, _ *types.APISchema) (types.APIObjectList, error) {
 	var rtn types.APIObjectList
 	pkgs, err := common.DefaultDB.ListPackages(nil)
 	if err != nil {
@@ -48,7 +48,7 @@ func (e *Store) List(apiOp *types.APIRequest, schema *types.APISchema) (types.AP
 	return rtn, nil
 }
 
-func (e *Store) Create(apiOp *types.APIRequest, schema *types.APISchema, data types.APIObject) (types.APIObject, error) {
+func (e *Store) Create(_ *types.APIRequest, _ *types.APISchema, data types.APIObject) (types.APIObject, error) {
 	rtn := common.Package{}
 	if err := convert.ToObj(data.Object, &rtn); err != nil {
 		return types.APIObject{}, err
@@ -68,7 +68,7 @@ func (e *Store) Create(apiOp *types.APIRequest, schema *types.APISchema, data ty
 	return saveAndDownload(rtn)
 }
 
-func (e *Store) Update(apiOp *types.APIRequest, schema *types.APISchema, data types.APIObject, id string) (types.APIObject, error) {
+func (e *Store) Update(_ *types.APIRequest, _ *types.APISchema, data types.APIObject, id string) (types.APIObject, error) {
 	currents, err := common.DefaultDB.ListPackages(&id)
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
@@ -103,7 +103,7 @@ func (e *Store) Update(apiOp *types.APIRequest, schema *types.APISchema, data ty
 	return saveAndDownload(current)
 }
 
-func (e *Store) Watch(apiOp *types.APIRequest, schema *types.APISchema, wr types.WatchRequest) (chan types.APIEvent, error) {
+func (e *Store) Watch(apiOp *types.APIRequest, schema *types.APISchema, _ types.WatchRequest) (chan types.APIEvent, error) {
 	return common.DefaultDB.Watch(apiOp, schema), nil
 }
 

--- a/pkg/server/store/provider/store.go
+++ b/pkg/server/store/provider/store.go
@@ -19,7 +19,7 @@ type Store struct {
 }
 
 // ByID returns provider by ID.
-func (p *Store) ByID(apiOp *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
+func (p *Store) ByID(_ *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
 	provider, err := providers.GetProvider(id)
 	if err != nil {
 		return types.APIObject{}, apierror.NewAPIError(validation.NotFound, err.Error())
@@ -28,7 +28,7 @@ func (p *Store) ByID(apiOp *types.APIRequest, schema *types.APISchema, id string
 }
 
 // List returns providers as list.
-func (p *Store) List(apiOp *types.APIRequest, schema *types.APISchema) (types.APIObjectList, error) {
+func (p *Store) List(_ *types.APIRequest, schema *types.APISchema) (types.APIObjectList, error) {
 	list := providers.ListProviders()
 	result := types.APIObjectList{}
 	for _, object := range list {

--- a/pkg/server/store/settings/store.go
+++ b/pkg/server/store/settings/store.go
@@ -41,7 +41,7 @@ func (s *Store) Update(apiOp *types.APIRequest, schema *types.APISchema, data ty
 }
 
 // ByID get setting information by name
-func (s *Store) ByID(apiOp *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
+func (s *Store) ByID(_ *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
 	setting, err := common.DefaultDB.GetSetting(id)
 	if err != nil {
 		return types.APIObject{}, err
@@ -57,7 +57,7 @@ func (s *Store) ByID(apiOp *types.APIRequest, schema *types.APISchema, id string
 }
 
 // List all settings
-func (s *Store) List(apiOp *types.APIRequest, schema *types.APISchema) (types.APIObjectList, error) {
+func (s *Store) List(_ *types.APIRequest, schema *types.APISchema) (types.APIObjectList, error) {
 	result := types.APIObjectList{}
 	settings, err := common.DefaultDB.ListSettings()
 	if err != nil {
@@ -74,6 +74,6 @@ func (s *Store) List(apiOp *types.APIRequest, schema *types.APISchema) (types.AP
 }
 
 // Watch watches Settings.
-func (s *Store) Watch(apiOp *types.APIRequest, schema *types.APISchema, w types.WatchRequest) (chan types.APIEvent, error) {
+func (s *Store) Watch(apiOp *types.APIRequest, schema *types.APISchema, _ types.WatchRequest) (chan types.APIEvent, error) {
 	return common.DefaultDB.Watch(apiOp, schema), nil
 }

--- a/pkg/server/store/sshkey/schema.go
+++ b/pkg/server/store/sshkey/schema.go
@@ -16,7 +16,7 @@ func ActionHandlers() map[string]http.Handler {
 	}
 }
 
-func exportHandler(w http.ResponseWriter, r *http.Request) {
+func exportHandler(_ http.ResponseWriter, r *http.Request) {
 	apiContext := types.GetAPIContext(r.Context())
 	name := apiContext.Name
 	sshkeys, err := common.DefaultDB.ListSSHKey(&name)

--- a/pkg/server/store/sshkey/store.go
+++ b/pkg/server/store/sshkey/store.go
@@ -17,7 +17,7 @@ type Store struct {
 	empty.Store
 }
 
-func (s *Store) Create(apiOp *types.APIRequest, schema *types.APISchema, data types.APIObject) (types.APIObject, error) {
+func (s *Store) Create(_ *types.APIRequest, _ *types.APISchema, data types.APIObject) (types.APIObject, error) {
 	rtn := common.SSHKey{}
 	if err := convert.ToObj(data.Object, &rtn); err != nil {
 		return types.APIObject{}, err
@@ -52,7 +52,7 @@ func (s *Store) Create(apiOp *types.APIRequest, schema *types.APISchema, data ty
 	return *common.GetAPIObject(rtn), nil
 }
 
-func (s *Store) List(apiOp *types.APIRequest, schema *types.APISchema) (types.APIObjectList, error) {
+func (s *Store) List(_ *types.APIRequest, _ *types.APISchema) (types.APIObjectList, error) {
 	var rtn types.APIObjectList
 	sshkeys, err := common.DefaultDB.ListSSHKey(nil)
 	if err != nil {
@@ -75,7 +75,7 @@ func (s *Store) Delete(apiOp *types.APIRequest, schema *types.APISchema, id stri
 	return rtn, common.DefaultDB.DeleteSSHKey(id)
 }
 
-func (s *Store) ByID(apiOp *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
+func (s *Store) ByID(_ *types.APIRequest, _ *types.APISchema, id string) (types.APIObject, error) {
 	rtn, err := common.DefaultDB.ListSSHKey(&id)
 	if err != nil {
 		return types.APIObject{}, err
@@ -85,6 +85,6 @@ func (s *Store) ByID(apiOp *types.APIRequest, schema *types.APISchema, id string
 	return *obj, nil
 }
 
-func (s *Store) Watch(apiOp *types.APIRequest, schema *types.APISchema, wr types.WatchRequest) (chan types.APIEvent, error) {
+func (s *Store) Watch(apiOp *types.APIRequest, schema *types.APISchema, _ types.WatchRequest) (chan types.APIEvent, error) {
 	return common.DefaultDB.Watch(apiOp, schema), nil
 }

--- a/pkg/server/store/template/store.go
+++ b/pkg/server/store/template/store.go
@@ -55,7 +55,7 @@ func (t *Store) Create(apiOp *types.APIRequest, schema *types.APISchema, data ty
 }
 
 // List returns templates as list.
-func (t *Store) List(apiOp *types.APIRequest, schema *types.APISchema) (types.APIObjectList, error) {
+func (t *Store) List(_ *types.APIRequest, schema *types.APISchema) (types.APIObjectList, error) {
 	result := types.APIObjectList{}
 	templates, err := common.DefaultDB.ListTemplates()
 	if err != nil {
@@ -111,7 +111,7 @@ func (t *Store) List(apiOp *types.APIRequest, schema *types.APISchema) (types.AP
 }
 
 // ByID returns template by ID.
-func (t *Store) ByID(apiOp *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
+func (t *Store) ByID(_ *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
 	context := strings.Split(id, ".")
 	if len(context) != 2 {
 		return types.APIObject{}, apierror.NewAPIError(validation.InvalidOption, fmt.Sprintf("invalid template id %s", id))
@@ -182,7 +182,7 @@ func (t *Store) Update(apiOp *types.APIRequest, schema *types.APISchema, data ty
 }
 
 // Delete deletes template by ID.
-func (t *Store) Delete(apiOp *types.APIRequest, schema *types.APISchema, id string) (types.APIObject, error) {
+func (t *Store) Delete(_ *types.APIRequest, _ *types.APISchema, id string) (types.APIObject, error) {
 	context := strings.Split(id, ".")
 	if len(context) != 2 {
 		return types.APIObject{}, apierror.NewAPIError(validation.InvalidOption, fmt.Sprintf("invalid template id %s", id))
@@ -192,7 +192,7 @@ func (t *Store) Delete(apiOp *types.APIRequest, schema *types.APISchema, id stri
 }
 
 // Watch watches template.
-func (t *Store) Watch(apiOp *types.APIRequest, schema *types.APISchema, w types.WatchRequest) (chan types.APIEvent, error) {
+func (t *Store) Watch(apiOp *types.APIRequest, schema *types.APISchema, _ types.WatchRequest) (chan types.APIEvent, error) {
 	result := make(chan types.APIEvent)
 	data := common.DefaultDB.Watch(apiOp, schema)
 	go func() {

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -77,12 +77,12 @@ func (s Setting) Set(value string) error {
 func GetScriptFromSource(writer io.Writer) error {
 	sourceURL := ScriptUpdateSource.Get()
 	if _, err := url.Parse(sourceURL); err != nil {
-		return errors.Wrap(err, "install script source url is not validated.")
+		return errors.Wrap(err, "install script source url is not validated")
 	}
 
 	resp, err := http.Get(sourceURL)
 	if err != nil {
-		return errors.Wrap(err, "failed to make request to install script source url.")
+		return errors.Wrap(err, "failed to make request to install script source url")
 	}
 	defer resp.Body.Close()
 

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -164,12 +164,9 @@ func MergeConfig(source, target reflect.Value) {
 }
 
 func waitForBackoff(fn func() (bool, error), backoff wait.Backoff) error {
-	if err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+	return wait.ExponentialBackoff(backoff, func() (bool, error) {
 		return fn()
-	}); err != nil {
-		return err
-	}
-	return nil
+	})
 }
 
 func StringSupportBase64(value string) string {


### PR DESCRIPTION
- Also upgraded golangci-lint version to adapt v1.20+ golang 
- And use revive linter instead of golint
- And lint fixes

As the SUSE BCI doesn't have v1.20.8 golang version, I use bci-base and install go v1.20.8 manually.

Refer to issue: https://github.com/cnrancher/autok3s/issues/634