### PR TITLE
fix(cluster): fix stuck in Upgrading status when join nodes failed

### DIFF
--- a/hack/lib/dapper.sh
+++ b/hack/lib/dapper.sh
@@ -19,7 +19,7 @@ function autok3s::dapper::validate() {
 
   autok3s::log::info "installing dapper"
   if autok3s::dapper::install; then
-    autok3s::log::info "dapper: $(dapper -v)"
+    autok3s::log::info "dapper: $(.dapper -v)"
     return 0
   fi
   autok3s::log::error "no dapper available"


### PR DESCRIPTION
## Issue
https://github.com/cnrancher/autok3s/issues/648

## Problem

The defer function can't catch the error correctly because the `err` is a new variable when calling Join node function. When the error occurs, the defer error function can't refresh the cluster status.

## Solution

Change to use the consistent `err` variables to ensure the error can be handled by the defer function. 

## Test

- Validate for `native` provider by creating cluster and join nodes cases. Check the cluster status can be refreshed correctly no matter success or fail.