### PR TITLE
feat(cluster): support setting install environment

### DIFF
--- a/pkg/cluster/commands.go
+++ b/pkg/cluster/commands.go
@@ -26,6 +26,15 @@ var (
 func getCommand(isFirstMaster bool, fixedIP string, cluster *types.Cluster, node types.Node, extraArgs []string) string {
 	var commandPrefix, commandSuffix string
 	envVar := map[string]string{}
+	// prepare for install env
+	for key, value := range cluster.InstallEnv {
+		if key == "INSTALL_K3S_EXEC" {
+			// add install exec to extraArgs
+			extraArgs = append(extraArgs, value)
+			continue
+		}
+		envVar[key] = value
+	}
 	// airgap install
 	if cluster.PackageName != "" || cluster.PackagePath != "" {
 		commandSuffix = "install.sh"

--- a/pkg/types/autok3s.go
+++ b/pkg/types/autok3s.go
@@ -60,6 +60,7 @@ type Metadata struct {
 	DataStoreKeyFileContent  string      `json:"datastore-keyfile-content,omitempty" yaml:"datastore-keyfile-content,omitempty"`
 	Rollback                 bool        `json:"rollback" yaml:"rollback" gorm:"type:bool"`
 	Values                   StringMap   `json:"values,omitempty" yaml:"values,omitempty" gorm:"type:stringMap"`
+	InstallEnv               StringMap   `json:"install-env,omitempty" yaml:"install-env,omitempty" gorm:"type:stringMap"`
 }
 
 // Status struct for status.


### PR DESCRIPTION
https://github.com/cnrancher/autok3s/issues/638

Support setting `INSTALL_*` environment variables defined in the K3s install script.

If users want to add environment variables for the K3s server or agent. We recommend using configuration file args. The configuration file args will be supported later.